### PR TITLE
Added information about count count locked/finished submissions

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
+import org.eclipse.swt.internal.win32.TCHAR;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -247,10 +248,7 @@ public class ArtemisGradingView extends ViewPart {
 
 		correctionCountLbl = new Label(assessmentComposite, SWT.NONE);
 		correctionCountLbl.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1));
-		
-		
-		correctionCountLbl.setText(String.format(""));
-		
+		correctionCountLbl.setText("");
 		
 		Label lblCourse = new Label(assessmentComposite, SWT.NONE);
 		lblCourse.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
@@ -503,7 +501,7 @@ public class ArtemisGradingView extends ViewPart {
 					sc.getBegunSubmissionsProjectNames(SubmissionFilter.SAVED_AND_SUBMITTED).size()));		
 			sc.getBegunSubmissionsProjectNames(SubmissionFilter.ALL).stream().forEach(System.out::println);
 		} else {
-			correctionCountLbl.setText(String.format(""));
+			correctionCountLbl.setText("");
 		}
 	}
 

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
@@ -23,10 +23,12 @@ import org.eclipse.swt.widgets.TabFolder;
 import org.eclipse.swt.widgets.TabItem;
 import org.eclipse.ui.part.ViewPart;
 
+import edu.kit.kastel.eclipse.grading.view.activator.Activator;
 import edu.kit.kastel.eclipse.grading.view.controllers.AssessmentViewController;
 import edu.kit.kastel.eclipse.grading.view.utilities.AssessmentUtilities;
 import edu.kit.kastel.sdq.eclipse.grading.api.artemis.mapping.SubmissionFilter;
 import edu.kit.kastel.sdq.eclipse.grading.api.backendstate.Transition;
+import edu.kit.kastel.sdq.eclipse.grading.api.controller.ISystemwideController;
 import edu.kit.kastel.sdq.eclipse.grading.api.model.IMistakeType;
 import edu.kit.kastel.sdq.eclipse.grading.api.model.IRatingGroup;
 
@@ -49,6 +51,7 @@ public class ArtemisGradingView extends ViewPart {
 	private Combo examCombo;
 	private Combo exerciseCombo;
 	private Combo courseCombo;
+	private Label correctionCountLbl;
 
 	public ArtemisGradingView() {
 		this.viewController = new AssessmentViewController();
@@ -242,10 +245,17 @@ public class ArtemisGradingView extends ViewPart {
 		Composite assessmentComposite = new Composite(scrolledCompositeAssessment, SWT.NONE);
 		assessmentComposite.setLayout(new GridLayout(2, false));
 
+		correctionCountLbl = new Label(assessmentComposite, SWT.NONE);
+		correctionCountLbl.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1));
+		
+		
+		correctionCountLbl.setText(String.format(""));
+		
+		
 		Label lblCourse = new Label(assessmentComposite, SWT.NONE);
 		lblCourse.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
 		lblCourse.setText("Course");
-
+		
 		this.courseCombo = new Combo(assessmentComposite, SWT.READ_ONLY);
 		this.courseCombo.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
 
@@ -476,6 +486,25 @@ public class ArtemisGradingView extends ViewPart {
 	private void updateState() {
 		this.possibleActions.values().forEach(set -> set.forEach(control -> control.setEnabled(false)));
 		this.viewController.getPossiblyTransitions().forEach(transition -> this.possibleActions.get(transition).forEach(control -> control.setEnabled(true)));
+		this.updateCorrectedSubmissionCount();
+	}
+	
+	/**
+	 * Updates the text above exam & exercise-selection according to the amount of assessed submissions (by the current tutor)
+	 * for the currently selected exercise (if selected; otherwise just an empty string)
+	 * Method is triggered by all invocations of updateState, hence a variety of {@link Transition}s could trigger a change.
+	 * (e.g. selecting another exercise, starting an assessment, submitting an assessment, ...)
+	 */
+	private void updateCorrectedSubmissionCount() {
+		if (this.exerciseCombo.getSelectionIndex() != -1) {
+			ISystemwideController sc = Activator.getDefault().getSystemwideController();
+			correctionCountLbl.setText(String.format("Started submissions: %d  Submitted: %d", 
+					sc.getBegunSubmissionsProjectNames(SubmissionFilter.ALL).size(),
+					sc.getBegunSubmissionsProjectNames(SubmissionFilter.SAVED_AND_SUBMITTED).size()));		
+			sc.getBegunSubmissionsProjectNames(SubmissionFilter.ALL).stream().forEach(System.out::println);
+		} else {
+			correctionCountLbl.setText(String.format(""));
+		}
 	}
 
 	private void addControlToPossibleActions(Control control, Transition transition) {


### PR DESCRIPTION
I added information about how many submissions are locked / submitted by a tutor right in the "Assessment" tab (as suggested in [ #132](https://github.com/kit-sdq/programming-lecture-eclipse-artemis/issues/132)).
This helps tutors to keep track about whether they need to start a new assessment for the selected task or not.

<em>Note:</em> the counter will be updated on every "updateState()" of the **ArtemisGradingView**. This might couse some false-triggers, however the counter has to be updated quite often anyway hence a lot of events (like selecting another exercise, starting an assessment, submitting an assessment, ...) could change the actual values that should be displayed.