### PR TITLE
Feature/bigger custom penalty text field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@ buildNumber.properties
 .mvn/wrapper/maven-wrapper.jar
 .polyglot.*
 .settings
+jvm/.project
+jvm/feature/.project
+jvm/linux/.classpath
+jvm/linux/.project
+jvm/windows/.classpath
+jvm/windows/.project
+releng/.project

--- a/.gitignore
+++ b/.gitignore
@@ -39,10 +39,4 @@ buildNumber.properties
 .mvn/wrapper/maven-wrapper.jar
 .polyglot.*
 .settings
-jvm/.project
-jvm/feature/.project
-jvm/linux/.classpath
-jvm/linux/.project
-jvm/windows/.classpath
-jvm/windows/.project
-releng/.project
+

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,3 @@ dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
 # https://github.com/takari/maven-wrapper#usage-without-binary-jar
-.mvn/wrapper/maven-wrapper.jar
-.polyglot.*
-.settings
-

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
 # https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+.polyglot.*
+.settings

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.api/src/edu/kit/kastel/sdq/eclipse/grading/api/PreferenceConstants.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.api/src/edu/kit/kastel/sdq/eclipse/grading/api/PreferenceConstants.java
@@ -11,6 +11,7 @@ public final class PreferenceConstants {
 	public static final String ARTEMIS_URL = "artemisUrl";
 	public static final String ARTEMIS_USER = "artemisUser";
 	public static final String ARTEMIS_PASSWORD = "artemisPassword";
+	public static final String PREFFERES_LARGE_PENALTY_TEXT_PATH = "userPreferresLargePenaltyText";
 
 	private PreferenceConstants() {
 		throw new IllegalAccessError();

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.api/src/edu/kit/kastel/sdq/eclipse/grading/api/PreferenceConstants.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.api/src/edu/kit/kastel/sdq/eclipse/grading/api/PreferenceConstants.java
@@ -11,7 +11,7 @@ public final class PreferenceConstants {
 	public static final String ARTEMIS_URL = "artemisUrl";
 	public static final String ARTEMIS_USER = "artemisUser";
 	public static final String ARTEMIS_PASSWORD = "artemisPassword";
-	public static final String PREFFERES_LARGE_PENALTY_TEXT_PATH = "userPreferresLargePenaltyText";
+	public static final String PREFERS_LARGE_PENALTY_TEXT_PATH = "userPreferresLargePenaltyText";
 
 	private PreferenceConstants() {
 		throw new IllegalAccessError();

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/CustomButtonDialog.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/CustomButtonDialog.java
@@ -11,7 +11,9 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.Text;
 
+import edu.kit.kastel.eclipse.grading.view.activator.Activator;
 import edu.kit.kastel.eclipse.grading.view.controllers.AssessmentViewController;
+import edu.kit.kastel.sdq.eclipse.grading.api.PreferenceConstants;
 import edu.kit.kastel.sdq.eclipse.grading.api.model.IMistakeType;
 
 /**
@@ -51,22 +53,38 @@ public class CustomButtonDialog extends Dialog {
 	@Override
 	protected Control createDialogArea(Composite parent) {
 		final Composite comp = (Composite) super.createDialogArea(parent);
+		
+		boolean userWantsBigWindow = Activator.getDefault().getPreferenceStore().getBoolean(PreferenceConstants.PREFFERES_LARGE_PENALTY_TEXT_PATH);
 
 		final GridLayout layout = (GridLayout) comp.getLayout();
-		layout.numColumns = 2;
+		layout.numColumns = userWantsBigWindow ? 1 : 2;
 
 		final Label customMessageLabel = new Label(comp, SWT.RIGHT);
 		customMessageLabel.setText("Custom Message: ");
-		this.customMessageInputField = new Text(comp, SWT.SINGLE | SWT.BORDER);
 
+		final GridData data = new GridData(SWT.FILL, SWT.CENTER, true, false);
+		
+		GridData customMessageInputFieldData;
+		if (userWantsBigWindow) {
+			this.customMessageInputField = new Text(comp, SWT.MULTI | SWT.BORDER | SWT.V_SCROLL  |SWT.H_SCROLL);
+			customMessageInputFieldData = new GridData(GridData.FILL_BOTH);
+			// Calculating height and width based on the lineHeight (theoretically) ensures proper scaling across screen-sizes.
+			// However lacking of a 4K-screen this has not been tested entirely.
+			customMessageInputFieldData.minimumHeight = this.customMessageInputField.getLineHeight() * 5;
+			customMessageInputFieldData.minimumWidth = this.customMessageInputField.getLineHeight() * 16;
+		} else {
+			this.customMessageInputField = new Text(comp, SWT.SINGLE | SWT.BORDER);
+			customMessageInputFieldData = data;
+		}
+		
 		final Label customPenaltyLabel = new Label(comp, SWT.RIGHT);
 		customPenaltyLabel.setText("Custom Penalty: ");
 		this.customPenaltyInputField = new Spinner(comp, SWT.SINGLE | SWT.BORDER);
 		this.customPenaltyInputField.setDigits(1);
 		this.customPenaltyInputField.setIncrement(5);
 
-		final GridData data = new GridData(SWT.FILL, SWT.CENTER, true, false);
-		this.customMessageInputField.setLayoutData(data);
+				
+		this.customMessageInputField.setLayoutData(customMessageInputFieldData);
 		this.customPenaltyInputField.setLayoutData(data);
 
 		return comp;

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/CustomButtonDialog.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/CustomButtonDialog.java
@@ -73,8 +73,8 @@ public class CustomButtonDialog extends Dialog {
 			
 			// Calculating height and width based on the lineHeight (theoretically) ensures proper scaling across screen-sizes.
 			// However lacking of a 4K-screen this has not been tested entirely.
-			customMessageInputFieldData.minimumHeight = this.customMessageInputField.getLineHeight() * 5;
-			customMessageInputFieldData.minimumWidth = this.customMessageInputField.getLineHeight() * 16;
+			customMessageInputFieldData.minimumHeight = this.customMessageInputField.getLineHeight() * 8;
+			customMessageInputFieldData.minimumWidth = this.customMessageInputField.getLineHeight() * 24;
 			
 			this.customMessageInputField.addKeyListener(new MultiLineTextEditorKeyListener());
 		} else {
@@ -121,8 +121,6 @@ public class CustomButtonDialog extends Dialog {
 	 * @author Shirkanesi
 	 */
 	private class MultiLineTextEditorKeyListener implements KeyListener {
-		private static final int LINE_SEPARATOR_LENGTH = System.lineSeparator().length();
-		private static final int RETURN_KEY_CODE = 13;
 		private boolean isShiftPressed;
 		
 		@Override
@@ -133,9 +131,14 @@ public class CustomButtonDialog extends Dialog {
 			}
 			
 			if (!this.isShiftPressed) {
-				if (e.keyCode == SWT.TAB || e.keyCode == RETURN_KEY_CODE) {
-					// Required due to Windows using \r\n, UNIX-like systems just \n
-					int insertedLength = e.keyCode == RETURN_KEY_CODE ? LINE_SEPARATOR_LENGTH : 1;
+				if (e.keyCode == SWT.TAB || isReturnCharacter(e.keyCode)) {
+					int insertedLength;
+					if (isReturnCharacter(e.keyCode)) {
+						// Required due to Windows using \r\n, UNIX-like systems just \n
+						insertedLength = System.lineSeparator().length();
+					} else {
+						insertedLength = 1;
+					}
 					
 					// Removed the inserted character(s)
 					int pos = customMessageInputField.getCaretPosition();
@@ -144,13 +147,17 @@ public class CustomButtonDialog extends Dialog {
 					customMessageInputField.setText(modified);
 					
 					// Determine how to jump out of the text-field (either by closing the dialog or selecting the penalty-input)
-					if (e.keyCode == RETURN_KEY_CODE) {
+					if (isReturnCharacter(e.keyCode)) {
 						okPressed();
 					} else {								
 						customPenaltyInputField.setFocus();
 					}
 				}				
 			}
+		}
+		
+		private boolean isReturnCharacter(int keyCode) {
+			return keyCode == SWT.CR || keyCode == SWT.LF;
 		}
 			
 		

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/CustomButtonDialog.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/CustomButtonDialog.java
@@ -121,6 +121,7 @@ public class CustomButtonDialog extends Dialog {
 	 * @author Shirkanesi
 	 */
 	private class MultiLineTextEditorKeyListener implements KeyListener {
+		private static final int LINE_SEPARATOR_LENGTH = System.lineSeparator().length();
 		private static final int RETURN_KEY_CODE = 13;
 		private boolean isShiftPressed;
 		
@@ -133,9 +134,10 @@ public class CustomButtonDialog extends Dialog {
 			
 			if (!this.isShiftPressed) {
 				if (e.keyCode == SWT.TAB || e.keyCode == RETURN_KEY_CODE) {
-					int insertedLength = e.keyCode == RETURN_KEY_CODE ? 2 : 1;
+					// Required due to Windows using \r\n, UNIX-like systems just \n
+					int insertedLength = e.keyCode == RETURN_KEY_CODE ? LINE_SEPARATOR_LENGTH : 1;
 					
-					// Removed the inserted character
+					// Removed the inserted character(s)
 					int pos = customMessageInputField.getCaretPosition();
 					String text = customMessageInputField.getText();
 					String modified = text.substring(0, pos - insertedLength) + text.substring(pos);

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/preferences/ArtemisGradingPreferencesPage.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/preferences/ArtemisGradingPreferencesPage.java
@@ -27,6 +27,7 @@ public class ArtemisGradingPreferencesPage extends FieldEditorPreferencePage imp
 	private BooleanFieldEditor isRelativeConfigPath;
 	private StringFieldEditor relativeConfigPath;
 	private FileFieldEditor absoluteConfigPath;
+	private BooleanFieldEditor userPreferresLargePenaltyText;
 
 	public ArtemisGradingPreferencesPage() {
 		super(FieldEditorPreferencePage.GRID);
@@ -56,6 +57,8 @@ public class ArtemisGradingPreferencesPage extends FieldEditorPreferencePage imp
 		StringFieldEditor artemisPassword = new StringFieldEditor(PreferenceConstants.ARTEMIS_PASSWORD, "Artemis password: ", this.getFieldEditorParent());
 
 		artemisPassword.getTextControl(this.getFieldEditorParent()).setEchoChar('*');
+		
+		this.userPreferresLargePenaltyText = new BooleanFieldEditor(PreferenceConstants.PREFFERES_LARGE_PENALTY_TEXT_PATH, "Use large text-box for custom penaltys (note: when enabled, you need to click \"ok\". Pressing enter won't add the penalty.)", this.getFieldEditorParent());
 
 		this.addField(this.absoluteConfigPath);
 		this.addField(this.relativeConfigPath);
@@ -63,6 +66,7 @@ public class ArtemisGradingPreferencesPage extends FieldEditorPreferencePage imp
 		this.addField(artemisUrl);
 		this.addField(artemisUser);
 		this.addField(artemisPassword);
+		this.addField(this.userPreferresLargePenaltyText);
 
 	}
 

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/preferences/ArtemisGradingPreferencesPage.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/preferences/ArtemisGradingPreferencesPage.java
@@ -27,7 +27,7 @@ public class ArtemisGradingPreferencesPage extends FieldEditorPreferencePage imp
 	private BooleanFieldEditor isRelativeConfigPath;
 	private StringFieldEditor relativeConfigPath;
 	private FileFieldEditor absoluteConfigPath;
-	private BooleanFieldEditor userPreferresLargePenaltyText;
+	private BooleanFieldEditor userPrefersLargePenaltyText;
 
 	public ArtemisGradingPreferencesPage() {
 		super(FieldEditorPreferencePage.GRID);
@@ -58,7 +58,7 @@ public class ArtemisGradingPreferencesPage extends FieldEditorPreferencePage imp
 
 		artemisPassword.getTextControl(this.getFieldEditorParent()).setEchoChar('*');
 		
-		this.userPreferresLargePenaltyText = new BooleanFieldEditor(PreferenceConstants.PREFFERES_LARGE_PENALTY_TEXT_PATH, "Use larger multi-line-text-box for custom penaltys", this.getFieldEditorParent());
+		this.userPrefersLargePenaltyText = new BooleanFieldEditor(PreferenceConstants.PREFERS_LARGE_PENALTY_TEXT_PATH, "Use larger multi-line-text-box for custom penaltys", this.getFieldEditorParent());
 
 		this.addField(this.absoluteConfigPath);
 		this.addField(this.relativeConfigPath);
@@ -66,7 +66,7 @@ public class ArtemisGradingPreferencesPage extends FieldEditorPreferencePage imp
 		this.addField(artemisUrl);
 		this.addField(artemisUser);
 		this.addField(artemisPassword);
-		this.addField(this.userPreferresLargePenaltyText);
+		this.addField(this.userPrefersLargePenaltyText);
 
 	}
 

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/preferences/ArtemisGradingPreferencesPage.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/preferences/ArtemisGradingPreferencesPage.java
@@ -58,7 +58,7 @@ public class ArtemisGradingPreferencesPage extends FieldEditorPreferencePage imp
 
 		artemisPassword.getTextControl(this.getFieldEditorParent()).setEchoChar('*');
 		
-		this.userPreferresLargePenaltyText = new BooleanFieldEditor(PreferenceConstants.PREFFERES_LARGE_PENALTY_TEXT_PATH, "Use large text-box for custom penaltys (note: when enabled, you need to click \"ok\". Pressing enter won't add the penalty.)", this.getFieldEditorParent());
+		this.userPreferresLargePenaltyText = new BooleanFieldEditor(PreferenceConstants.PREFFERES_LARGE_PENALTY_TEXT_PATH, "Use larger multi-line-text-box for custom penaltys", this.getFieldEditorParent());
 
 		this.addField(this.absoluteConfigPath);
 		this.addField(this.relativeConfigPath);

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/preferences/PreferenceInitializer.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/preferences/PreferenceInitializer.java
@@ -20,6 +20,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		store.setDefault(PreferenceConstants.ARTEMIS_URL, "");
 		store.setDefault(PreferenceConstants.ARTEMIS_USER, "");
 		store.setDefault(PreferenceConstants.ARTEMIS_PASSWORD, "");
+		store.setDefault(PreferenceConstants.PREFFERES_LARGE_PENALTY_TEXT_PATH, "false");
 	}
 
 }

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/preferences/PreferenceInitializer.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/preferences/PreferenceInitializer.java
@@ -20,7 +20,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		store.setDefault(PreferenceConstants.ARTEMIS_URL, "");
 		store.setDefault(PreferenceConstants.ARTEMIS_USER, "");
 		store.setDefault(PreferenceConstants.ARTEMIS_PASSWORD, "");
-		store.setDefault(PreferenceConstants.PREFFERES_LARGE_PENALTY_TEXT_PATH, "false");
+		store.setDefault(PreferenceConstants.PREFERS_LARGE_PENALTY_TEXT_PATH, "false");
 	}
 
 }


### PR DESCRIPTION
As requested in #131 I started implementing a bigger text-box for custom penalties.

To not surprise the user, there is now a config-option enabling this feature.
Also the way `ENTER` and `TAB` is handled in multiline-text is a bit hacky, since I tried to still allow pressing `ENTER` to create the penalty. This is done through listening to key-presses in the text-box and (in case of `ENTER` or `TAB`) replacing the typed caracter and executing the proper action.
If you want to create a newline or tab character, you need to type `SHIFT + (ENTER | TAB)`

However, there are still things to test:
(would be nice, if someone with this hard-/software could test this)
- [ ] Test the scaling of the multiline-textbox on higher screen resolutions
  - [x] 2736 x 1824
  - [ ] 1440p
  - [x] 4K
- [x] Test the emulation of `ENTER` and `TAB` presses in the multiline-box on different operating systems (hence this might depend on the line-separator of the OS).
Tested so far: 
  - [x] Windows 11 
  - [x] Windows 10
  - [x] Linux (Mint or Ubuntu)
  - [x] Mac OS