### PR TITLE
`Feature` custom message for non custom penalties

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationMapper.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationMapper.java
@@ -207,7 +207,7 @@ public class AnnotationMapper {
 		} else {
 			detailText += mistakeType.getMessage();
 			if (annotation.getCustomMessage().isPresent()) {
-				detailText += "<br />Explaination: " + annotation.getCustomMessage().get();
+				detailText += "<br />Explanation: " + annotation.getCustomMessage().get();
 			}
 		}
 

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationMapper.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationMapper.java
@@ -7,6 +7,7 @@ import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -23,6 +24,7 @@ import edu.kit.kastel.sdq.eclipse.grading.api.model.IAnnotation;
 import edu.kit.kastel.sdq.eclipse.grading.api.model.IMistakeType;
 import edu.kit.kastel.sdq.eclipse.grading.api.model.IRatingGroup;
 import edu.kit.kastel.sdq.eclipse.grading.core.artemis.calculation.IPenaltyCalculationStrategy;
+import edu.kit.kastel.sdq.eclipse.grading.core.model.annotation.Annotation;
 
 /**
  * Maps Annotations to Artemis-accepted json-formatted strings.
@@ -204,11 +206,14 @@ public class AnnotationMapper {
 			detailText += annotation.getCustomMessage().get() + " (" + nf.format(-annotation.getCustomPenalty().get()) + "P)";
 		} else {
 			detailText += mistakeType.getMessage();
+			if (annotation.getCustomMessage().isPresent()) {
+				detailText += "<br />Explaination: " + annotation.getCustomMessage().get();
+			}
 		}
 
 		return new Feedback(FeedbackType.MANUAL.name(), 0D, null, null, null, text, reference, detailText);
 	}
-
+	
 	private Feedback createNewManualUnreferencedFeedback(IRatingGroup ratingGroup) {
 		final double calculatedPenalty = this.calculatePenaltyForRatingGroup(ratingGroup);
 

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationMapper.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationMapper.java
@@ -25,7 +25,6 @@ import edu.kit.kastel.sdq.eclipse.grading.api.model.IAnnotation;
 import edu.kit.kastel.sdq.eclipse.grading.api.model.IMistakeType;
 import edu.kit.kastel.sdq.eclipse.grading.api.model.IRatingGroup;
 import edu.kit.kastel.sdq.eclipse.grading.core.artemis.calculation.IPenaltyCalculationStrategy;
-import edu.kit.kastel.sdq.eclipse.grading.core.model.annotation.Annotation;
 
 /**
  * Maps Annotations to Artemis-accepted json-formatted strings.

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
@@ -75,7 +75,7 @@ public class ArtemisGradingView extends ViewPart {
 				.addResourceChangeListener(event -> Arrays.asList(event.findMarkerDeltas(AssessmentUtilities.MARKER_NAME, true)).forEach(marker -> {
 					// check if marker is deleted
 					if (marker.getKind() == 2) {
-						this.viewController.deleteAnnotation((String) marker.getAttribute("annotationID"));
+						this.viewController.deleteAnnotation((String) marker.getAttribute(AssessmentUtilities.MARKER_ANNOTATION_ID));
 						this.updatePenalties();
 					}
 				}));

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
@@ -75,7 +75,7 @@ public class ArtemisGradingView extends ViewPart {
 				.addResourceChangeListener(event -> Arrays.asList(event.findMarkerDeltas(AssessmentUtilities.MARKER_NAME, true)).forEach(marker -> {
 					// check if marker is deleted
 					if (marker.getKind() == 2) {
-						this.viewController.deleteAnnotation((String) marker.getAttribute(AssessmentUtilities.MARKER_ANNOTATION_ID));
+						this.viewController.deleteAnnotation((String) marker.getAttribute(AssessmentUtilities.MARKER_ATTRIBUTE_ANNOTATION_ID));
 						this.updatePenalties();
 					}
 				}));

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.swing.JOptionPane;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.layout.GridData;

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
@@ -379,24 +379,22 @@ public class ArtemisGradingView extends ViewPart {
 
 					this.mistakeButtons.put(mistake.getId(), mistakeButton);
 					mistakeButton.setToolTipText(this.viewController.getToolTipForMistakeType(mistake));
-					
-					KeyboardAwareMouseListener listener = KeyboardAwareMouseListener.builder()
-							.onShiftClick(() -> {
-								this.createMistakePenaltyWithCustomMessageDialog(mistake);	
-							})
-							.onMiddleClick(() -> {
-								this.createMistakePenaltyWithCustomMessageDialog(mistake);	
-							})
-							.onLeftClick(() -> {
-								this.viewController.addAssessmentAnnotation(mistake, null, null, mistake.getRatingGroup().getDisplayName());
-							})
-							.onClick(() -> {
-								this.updatePenalty(mistake.getRatingGroup().getDisplayName());
-								this.updateMistakeButtonToolTips(mistake);
-							})
-							.build();
+			
+					KeyboardAwareMouseListener listener = new KeyboardAwareMouseListener();
+					// Normal click
+					listener.setClickHandler(() -> {
+						this.viewController.addAssessmentAnnotation(mistake, null, null, mistake.getRatingGroup().getDisplayName());
+					}, SWT.BUTTON1);
+					// shift-click and middle-click
+					listener.setClickHandler(() -> {
+						this.createMistakePenaltyWithCustomMessageDialog(mistake);	
+					}, SWT.SHIFT, SWT.BUTTON2);
+					// every click
+					listener.setClickHandlerForEveryClick(() -> {
+						this.updatePenalty(mistake.getRatingGroup().getDisplayName());
+						this.updateMistakeButtonToolTips(mistake);
+					});
 					mistakeButton.addMouseListener(listener);
-					
 				}
 			});
 		});

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/CustomButtonDialog.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/CustomButtonDialog.java
@@ -36,6 +36,7 @@ public class CustomButtonDialog extends Dialog {
 	private IMistakeType customMistake;
 	private final AssessmentViewController viewController;
 	private final String ratingGroupName;
+	private boolean closedByOk;
 
 	public CustomButtonDialog(Shell parentShell, AssessmentViewController viewController, String ratingGroupName, IMistakeType mistake) {
 		super(parentShell);
@@ -53,7 +54,7 @@ public class CustomButtonDialog extends Dialog {
 	@Override
 	protected void configureShell(Shell newShell) {
 		super.configureShell(newShell);
-		newShell.setText("Create custom error");
+		newShell.setText("Create custom penalty");
 	}
 
 	@Override
@@ -86,14 +87,17 @@ public class CustomButtonDialog extends Dialog {
 			customMessageInputFieldData = data;
 		}
 		
-		final Label customPenaltyLabel = new Label(comp, SWT.RIGHT);
-		customPenaltyLabel.setText("Custom Penalty: ");
-		this.customPenaltyInputField = new Spinner(comp, SWT.SINGLE | SWT.BORDER);
-		this.customPenaltyInputField.setDigits(1);
-		this.customPenaltyInputField.setIncrement(5);
+		
 				
 		this.customMessageInputField.setLayoutData(customMessageInputFieldData);
-		this.customPenaltyInputField.setLayoutData(data);
+		if (this.customMistake != null) {	// Don't display the spinner if points are determined internally. 
+			final Label customPenaltyLabel = new Label(comp, SWT.RIGHT);
+			customPenaltyLabel.setText("Custom Penalty: ");
+			this.customPenaltyInputField = new Spinner(comp, SWT.SINGLE | SWT.BORDER);
+			this.customPenaltyInputField.setDigits(1);
+			this.customPenaltyInputField.setIncrement(5);
+			this.customPenaltyInputField.setLayoutData(data);			
+		}
 
 		return comp;
 	}
@@ -108,10 +112,21 @@ public class CustomButtonDialog extends Dialog {
 
 	@Override
 	protected void okPressed() {
+		this.closedByOk = true;
 		this.customMessage = this.customMessageInputField.getText();
-		this.customPenalty = Double.parseDouble(this.customPenaltyInputField.getText().replace(',', '.'));
-		this.viewController.addAssessmentAnnotation(this.customMistake, this.customMessage, this.customPenalty, this.ratingGroupName);
+		if (this.customMistake != null) {	// don't create an annotation iff the annotation is generated externally.
+			this.customPenalty = Double.parseDouble(this.customPenaltyInputField.getText().replace(',', '.'));
+			this.viewController.addAssessmentAnnotation(this.customMistake, this.customMessage, this.customPenalty, this.ratingGroupName);
+		}
 		super.okPressed();
+	}
+	
+	/**
+	 * Check to figure out how the dialog was closed
+	 * @return true iff the user clicked on ok, false if not.
+	 */
+	public boolean isClosedByOk() {
+		return closedByOk;
 	}
 	
 	/**

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/controllers/AssessmentViewController.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/controllers/AssessmentViewController.java
@@ -75,7 +75,7 @@ public class AssessmentViewController {
 		try {
 			String uuid = IAnnotation.createUUID();
 			IMarker marker = AssessmentUtilities.getCurrentlyOpenFile().createMarker(AssessmentUtilities.MARKER_NAME);
-			marker.setAttribute(AssessmentUtilities.MARKER_ANNOTATION_ID, uuid);
+			marker.setAttribute(AssessmentUtilities.MARKER_ATTRIBUTE_ANNOTATION_ID, uuid);
 			marker.setAttribute(IMarker.CHAR_START, charStart);
 			marker.setAttribute(IMarker.CHAR_END, charEnd);
 			marker.setAttribute(AssessmentUtilities.MARKER_ATTRIBUTE_ERROR_DESCRIPTION, mistake.isCustomPenalty() ? "" : mistake.getMessage());
@@ -144,7 +144,7 @@ public class AssessmentViewController {
 		try {
 			IMarker[] markers = AssessmentUtilities.getFile(annotation.getClassFilePath(), this.systemwideController.getCurrentProjectName()).findMarkers(null, false, 100);
 			for (IMarker marker : markers) {
-				if (annotation.getUUID().equals(marker.getAttribute(AssessmentUtilities.MARKER_ANNOTATION_ID))) {
+				if (annotation.getUUID().equals(marker.getAttribute(AssessmentUtilities.MARKER_ATTRIBUTE_ANNOTATION_ID))) {
 					return true;
 				}
 			}
@@ -165,7 +165,7 @@ public class AssessmentViewController {
 		try {
 			IMarker marker = AssessmentUtilities.getFile(annotation.getClassFilePath(), this.systemwideController.getCurrentProjectName())
 					.createMarker(AssessmentUtilities.MARKER_NAME);
-			marker.setAttribute(AssessmentUtilities.MARKER_ANNOTATION_ID, annotation.getUUID());
+			marker.setAttribute(AssessmentUtilities.MARKER_ATTRIBUTE_ANNOTATION_ID, annotation.getUUID());
 			marker.setAttribute(IMarker.CHAR_START, annotation.getMarkerCharStart());
 			marker.setAttribute(IMarker.CHAR_END, annotation.getMarkerCharEnd());
 

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/controllers/AssessmentViewController.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/controllers/AssessmentViewController.java
@@ -21,6 +21,7 @@ import edu.kit.kastel.sdq.eclipse.grading.api.controller.ISystemwideController;
 import edu.kit.kastel.sdq.eclipse.grading.api.model.IAnnotation;
 import edu.kit.kastel.sdq.eclipse.grading.api.model.IMistakeType;
 import edu.kit.kastel.sdq.eclipse.grading.api.model.IRatingGroup;
+import edu.kit.kastel.sdq.eclipse.grading.core.AssessmentController;
 
 /**
  * This class is the controller for the grading view. It creates the marker for
@@ -91,7 +92,7 @@ public class AssessmentViewController {
 			}
 			if (!mistake.isCustomPenalty()) {
 				marker.setAttribute(IMarker.MESSAGE, AssessmentUtilities.createMarkerTooltip(startLine, endLine, mistake.getButtonText(),
-						mistake.getRatingGroup().getDisplayName(), mistake.getMessage(), null));
+						mistake.getRatingGroup().getDisplayName(), formatCustomPenaltyMessage(mistake, customMessage), null));
 			} else {
 				marker.setAttribute(IMarker.MESSAGE, AssessmentUtilities.createMarkerTooltipForCustomButton(startLine, endLine, customMessage, customPenalty));
 			}
@@ -107,6 +108,21 @@ public class AssessmentViewController {
 			this.alertObserver.error("Unable to create marker for annotation", e);
 		}
 
+	}
+	
+	/**
+	 * Formats a custom penalty message. It will always use the message of the mistake, however iff the provided customMessage
+	 * is not null, it will append a \n and this custom message.
+	 * @param mistake the mistake to load the message from
+	 * @param customMessage the custom message to append (can be null)
+	 * @return the formatted message
+	 */
+	private String formatCustomPenaltyMessage(IMistakeType mistake, String customMessage) {
+		if (customMessage != null) {
+			return mistake.getMessage() + "\n" + customMessage;
+		} else {
+			return mistake.getMessage();
+		}
 	}
 
 	/**
@@ -145,7 +161,7 @@ public class AssessmentViewController {
 				marker.setAttribute(AssessmentUtilities.MARKER_ATTRIBUTE_RATING_GROUP, mistake.getRatingGroup().getDisplayName());
 				if (!mistake.isCustomPenalty()) {
 					marker.setAttribute(IMarker.MESSAGE, AssessmentUtilities.createMarkerTooltip(startLine, endLine, mistake.getButtonText(),
-							mistake.getRatingGroup().getDisplayName(), mistake.getMessage(), annotation.getClassFilePath()));
+							mistake.getRatingGroup().getDisplayName(), formatCustomPenaltyMessage(mistake, customMessage), annotation.getClassFilePath()));
 				} else {
 					marker.setAttribute(IMarker.MESSAGE,
 							AssessmentUtilities.createMarkerTooltipForCustomButton(startLine, endLine, customMessage, Double.parseDouble(customPenalty)));

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/controllers/AssessmentViewController.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/controllers/AssessmentViewController.java
@@ -22,7 +22,6 @@ import edu.kit.kastel.sdq.eclipse.grading.api.controller.ISystemwideController;
 import edu.kit.kastel.sdq.eclipse.grading.api.model.IAnnotation;
 import edu.kit.kastel.sdq.eclipse.grading.api.model.IMistakeType;
 import edu.kit.kastel.sdq.eclipse.grading.api.model.IRatingGroup;
-import edu.kit.kastel.sdq.eclipse.grading.core.AssessmentController;
 
 /**
  * This class is the controller for the grading view. It creates the marker for
@@ -76,7 +75,7 @@ public class AssessmentViewController {
 		try {
 			String uuid = IAnnotation.createUUID();
 			IMarker marker = AssessmentUtilities.getCurrentlyOpenFile().createMarker(AssessmentUtilities.MARKER_NAME);
-			marker.setAttribute("annotationID", uuid);
+			marker.setAttribute(AssessmentUtilities.MARKER_ANNOTATION_ID, uuid);
 			marker.setAttribute(IMarker.CHAR_START, charStart);
 			marker.setAttribute(IMarker.CHAR_END, charEnd);
 			marker.setAttribute(AssessmentUtilities.MARKER_ATTRIBUTE_ERROR_DESCRIPTION, mistake.isCustomPenalty() ? "" : mistake.getMessage());
@@ -145,7 +144,7 @@ public class AssessmentViewController {
 		try {
 			IMarker[] markers = AssessmentUtilities.getFile(annotation.getClassFilePath(), this.systemwideController.getCurrentProjectName()).findMarkers(null, false, 100);
 			for (IMarker marker : markers) {
-				if (annotation.getUUID().equals(marker.getAttribute("annotationID"))) {
+				if (annotation.getUUID().equals(marker.getAttribute(AssessmentUtilities.MARKER_ANNOTATION_ID))) {
 					return true;
 				}
 			}
@@ -166,7 +165,7 @@ public class AssessmentViewController {
 		try {
 			IMarker marker = AssessmentUtilities.getFile(annotation.getClassFilePath(), this.systemwideController.getCurrentProjectName())
 					.createMarker(AssessmentUtilities.MARKER_NAME);
-			marker.setAttribute("annotationID", annotation.getUUID());
+			marker.setAttribute(AssessmentUtilities.MARKER_ANNOTATION_ID, annotation.getUUID());
 			marker.setAttribute(IMarker.CHAR_START, annotation.getMarkerCharStart());
 			marker.setAttribute(IMarker.CHAR_END, annotation.getMarkerCharEnd());
 

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/listeners/KeyboardAwareMouseListener.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/listeners/KeyboardAwareMouseListener.java
@@ -1,50 +1,71 @@
 package edu.kit.kastel.eclipse.grading.view.listeners;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.MouseListener;
 
+/**
+ * This class provides a {@link MouseListener} which supports different handlers
+ * if specific keys on the keyboard are pressed while clicking.
+ * However, this listener will only listen to the {@link MouseListener#mouseUp(MouseEvent)}
+ * 
+ * @author Shirkanesi
+ */
 public class KeyboardAwareMouseListener implements MouseListener {
 
-	private Runnable onShiftClick;
-	private Runnable onCtrlClick;
-	private Runnable onAltClick;
-	private Runnable onLeftClick;
-	private Runnable onMiddleClick;
-	private Runnable onRightClick;
-	private Runnable onClick;
-	
-	
+	private final Map<Integer, Runnable> listeners;
+	private Runnable onEveryClick;
+
+	public KeyboardAwareMouseListener() {
+		this.listeners = new HashMap<>();
+	}
+
 	@Override
 	public void mouseUp(MouseEvent e) {
-		if ((e.stateMask & SWT.SHIFT) == SWT.SHIFT) {
-			this.invokeClickHandler(onShiftClick);
-		}
-		if ((e.stateMask & SWT.CTRL) == SWT.CTRL) {
-			this.invokeClickHandler(onCtrlClick);
-		}
-		if ((e.stateMask & SWT.ALT) == SWT.ALT) {
-			this.invokeClickHandler(onAltClick);
-		}
-		if (e.stateMask == SWT.BUTTON1) {	// Special handling, hence SWT.BUTTON1 is always set iff mouse is pressed
-			this.invokeClickHandler(onLeftClick);
-		}
-		if ((e.stateMask & SWT.BUTTON2) == SWT.BUTTON2) {
-			this.invokeClickHandler(onMiddleClick);
-		}
-		if ((e.stateMask & SWT.BUTTON3) == SWT.BUTTON3) {
-			this.invokeClickHandler(onRightClick);
-		}
-		this.invokeClickHandler(onClick);
+		this.invokeClickHandler(this.listeners.get(e.stateMask));
+		this.invokeClickHandler(onEveryClick);
 	}
-	
+
+	/**
+	 * Sets the click-handler which will be called on every click this listeners
+	 * handles. This handler will be invoked <strong>after</strong> all other
+	 * handlers.
+	 * 
+	 * @param handler the handler to be set
+	 */
+	public void setClickHandlerForEveryClick(Runnable handler) {
+		this.onEveryClick = handler;
+	}
+
+	/**
+	 * Sets a click-handler for all the button-masks supplied as second parameter.
+	 * Those masks are specified by the constant in {@link SWT} (e.g. SWT.SHIFT). By
+	 * supplying multiple masks the handler will be bound to multiple events (those
+	 * individual masks)
+	 * 
+	 * @param handler the handler to be set
+	 * @param masks   the masks the handler should be invoked on.
+	 */
+	public void setClickHandler(Runnable handler, int... masks) {
+		for (int mask : masks) {
+			if ((mask & SWT.BUTTON2) == SWT.BUTTON2 || (mask & SWT.BUTTON3) == SWT.BUTTON3) {
+				// the two other buttons won't fire the normal click
+				this.listeners.put(mask, handler);
+			} else {
+				this.listeners.put(mask | SWT.BUTTON1, handler);
+			}
+		}
+	}
+
 	private void invokeClickHandler(Runnable handler) {
 		if (handler != null) {
 			handler.run();
 		}
 	}
-	
-	
+
 	@Override
 	public void mouseDoubleClick(MouseEvent e) {
 		// NOP
@@ -53,58 +74,6 @@ public class KeyboardAwareMouseListener implements MouseListener {
 	@Override
 	public void mouseDown(MouseEvent e) {
 		// NOP
-	}
-	
-	public static Builder builder() {
-		return new Builder();
-	}
-	
-	public static class Builder {
-		
-		private final KeyboardAwareMouseListener listener;
-		
-		public Builder() {
-			this.listener = new KeyboardAwareMouseListener();
-		}
-		
-		public Builder onShiftClick(Runnable runnable) {
-			this.listener.onShiftClick = runnable;
-			return this;
-		}
-		
-		public Builder onCtrlClick(Runnable runnable) {
-			this.listener.onCtrlClick = runnable;
-			return this;
-		}
-		
-		public Builder onAltClick(Runnable runnable) {
-			this.listener.onAltClick = runnable;
-			return this;
-		}
-		
-		public Builder onLeftClick(Runnable runnable) {
-			this.listener.onLeftClick = runnable;
-			return this;
-		}
-		
-		public Builder onMiddleClick(Runnable runnable) {
-			this.listener.onMiddleClick = runnable;
-			return this;
-		}
-		
-		public Builder onRightClick(Runnable runnable) {
-			this.listener.onRightClick = runnable;
-			return this;
-		}
-		
-		public Builder onClick(Runnable runnable) {
-			this.listener.onClick = runnable;
-			return this;
-		}
-		
-		public KeyboardAwareMouseListener build() {
-			return this.listener;
-		}
 	}
 
 }

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/listeners/KeyboardAwareMouseListener.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/listeners/KeyboardAwareMouseListener.java
@@ -1,0 +1,110 @@
+package edu.kit.kastel.eclipse.grading.view.listeners;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.events.MouseListener;
+
+public class KeyboardAwareMouseListener implements MouseListener {
+
+	private Runnable onShiftClick;
+	private Runnable onCtrlClick;
+	private Runnable onAltClick;
+	private Runnable onLeftClick;
+	private Runnable onMiddleClick;
+	private Runnable onRightClick;
+	private Runnable onClick;
+	
+	
+	@Override
+	public void mouseUp(MouseEvent e) {
+		if ((e.stateMask & SWT.SHIFT) == SWT.SHIFT) {
+			this.invokeClickHandler(onShiftClick);
+		}
+		if ((e.stateMask & SWT.CTRL) == SWT.CTRL) {
+			this.invokeClickHandler(onCtrlClick);
+		}
+		if ((e.stateMask & SWT.ALT) == SWT.ALT) {
+			this.invokeClickHandler(onAltClick);
+		}
+		if (e.stateMask == SWT.BUTTON1) {	// Special handling, hence SWT.BUTTON1 is always set iff mouse is pressed
+			this.invokeClickHandler(onLeftClick);
+		}
+		if ((e.stateMask & SWT.BUTTON2) == SWT.BUTTON2) {
+			this.invokeClickHandler(onMiddleClick);
+		}
+		if ((e.stateMask & SWT.BUTTON3) == SWT.BUTTON3) {
+			this.invokeClickHandler(onRightClick);
+		}
+		this.invokeClickHandler(onClick);
+	}
+	
+	private void invokeClickHandler(Runnable handler) {
+		if (handler != null) {
+			handler.run();
+		}
+	}
+	
+	
+	@Override
+	public void mouseDoubleClick(MouseEvent e) {
+		// NOP
+	}
+
+	@Override
+	public void mouseDown(MouseEvent e) {
+		// NOP
+	}
+	
+	public static Builder builder() {
+		return new Builder();
+	}
+	
+	public static class Builder {
+		
+		private final KeyboardAwareMouseListener listener;
+		
+		public Builder() {
+			this.listener = new KeyboardAwareMouseListener();
+		}
+		
+		public Builder onShiftClick(Runnable runnable) {
+			this.listener.onShiftClick = runnable;
+			return this;
+		}
+		
+		public Builder onCtrlClick(Runnable runnable) {
+			this.listener.onCtrlClick = runnable;
+			return this;
+		}
+		
+		public Builder onAltClick(Runnable runnable) {
+			this.listener.onAltClick = runnable;
+			return this;
+		}
+		
+		public Builder onLeftClick(Runnable runnable) {
+			this.listener.onLeftClick = runnable;
+			return this;
+		}
+		
+		public Builder onMiddleClick(Runnable runnable) {
+			this.listener.onMiddleClick = runnable;
+			return this;
+		}
+		
+		public Builder onRightClick(Runnable runnable) {
+			this.listener.onRightClick = runnable;
+			return this;
+		}
+		
+		public Builder onClick(Runnable runnable) {
+			this.listener.onClick = runnable;
+			return this;
+		}
+		
+		public KeyboardAwareMouseListener build() {
+			return this.listener;
+		}
+	}
+
+}

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/utilities/AssessmentUtilities.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/utilities/AssessmentUtilities.java
@@ -26,6 +26,7 @@ import org.eclipse.ui.texteditor.ITextEditor;
 public final class AssessmentUtilities {
 
 	public static final String MARKER_NAME = "edu.kit.kastel.eclipse.grading.view.assessment.marker";
+	public static final String MARKER_ANNOTATION_ID = "annotationID";
 	public static final String MARKER_ATTRIBUTE_ERROR = "errorType";
 	public static final String MARKER_ATTRIBUTE_ERROR_DESCRIPTION = "errorTypeDescription";
 	public static final String MARKER_ATTRIBUTE_CLASS_NAME = "className";

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/utilities/AssessmentUtilities.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/utilities/AssessmentUtilities.java
@@ -26,7 +26,7 @@ import org.eclipse.ui.texteditor.ITextEditor;
 public final class AssessmentUtilities {
 
 	public static final String MARKER_NAME = "edu.kit.kastel.eclipse.grading.view.assessment.marker";
-	public static final String MARKER_ANNOTATION_ID = "annotationID";
+	public static final String MARKER_ATTRIBUTE_ANNOTATION_ID = "annotationID";
 	public static final String MARKER_ATTRIBUTE_ERROR = "errorType";
 	public static final String MARKER_ATTRIBUTE_ERROR_DESCRIPTION = "errorTypeDescription";
 	public static final String MARKER_ATTRIBUTE_CLASS_NAME = "className";


### PR DESCRIPTION
As already said in #83 I started to work on the feature to create penalties defined by the JSON but also add an additional custom message to them.
Currently I decided shift-clicking and middle-clicking the penalty-button is a good way to open this message-dialog. However, this can be changed or extended to other triggers.

The annotations are created by simply appending the customMessage to the message of the mistake (Separated by `<br/>Explanation:`). (Of course only iff there is a customMessage present)
The JSON-format was not modified, because the mistake and the customMessage can be stored simultaniously by the old system.

ToDo:
- [x] Cleanup code and imports
- [x] Test compatibility with old versions of the plugin (to make sure nothing breaks)
- [x] Test the code on multiple systems (I don't known what could break, but I'll do it anyway)
  - [x] Windows 11
  - [x] Windows 10
  - [x] Linux Mint

Screenshots:
![grafik](https://user-images.githubusercontent.com/30196411/145652193-ff2f0d5f-e995-40e6-8c8f-0cf592ff996c.png)
![grafik](https://user-images.githubusercontent.com/30196411/145652250-f458c7d4-3d4a-4648-a6fe-9c2d7dc11072.png)
