### PR TITLE
`Feature`: Added option to use line-wrapping in custom penalty text-field

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.api/src/edu/kit/kastel/sdq/eclipse/grading/api/PreferenceConstants.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.api/src/edu/kit/kastel/sdq/eclipse/grading/api/PreferenceConstants.java
@@ -12,6 +12,7 @@ public final class PreferenceConstants {
 	public static final String ARTEMIS_USER = "artemisUser";
 	public static final String ARTEMIS_PASSWORD = "artemisPassword";
 	public static final String PREFERS_LARGE_PENALTY_TEXT_PATH = "userPreferresLargePenaltyText";
+	public static final String PREFERS_TEXT_WRAPPING_IN_PENALTY_TEXT_PATH = "userPrefersTextWrappingInPenaltyText";
 
 	private PreferenceConstants() {
 		throw new IllegalAccessError();

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/CustomButtonDialog.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/CustomButtonDialog.java
@@ -72,7 +72,8 @@ public class CustomButtonDialog extends Dialog {
 		
 		GridData customMessageInputFieldData;
 		if (userWantsBigWindow) {
-			this.customMessageInputField = new Text(comp, SWT.MULTI | SWT.BORDER | SWT.V_SCROLL  |SWT.H_SCROLL);
+			int textWrapping = Activator.getDefault().getPreferenceStore().getBoolean(PreferenceConstants.PREFERS_TEXT_WRAPPING_IN_PENALTY_TEXT_PATH) ? SWT.WRAP : 0;
+			this.customMessageInputField = new Text(comp, SWT.MULTI | SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL | textWrapping);
 			customMessageInputFieldData = new GridData(GridData.FILL_BOTH);
 			
 			// Calculating height and width based on the lineHeight (theoretically) ensures proper scaling across screen-sizes.

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/preferences/ArtemisGradingPreferencesPage.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/preferences/ArtemisGradingPreferencesPage.java
@@ -28,6 +28,7 @@ public class ArtemisGradingPreferencesPage extends FieldEditorPreferencePage imp
 	private StringFieldEditor relativeConfigPath;
 	private FileFieldEditor absoluteConfigPath;
 	private BooleanFieldEditor userPrefersLargePenaltyText;
+	private BooleanFieldEditor userPrefersTextWrappingInPenaltyText;
 
 	public ArtemisGradingPreferencesPage() {
 		super(FieldEditorPreferencePage.GRID);
@@ -59,6 +60,7 @@ public class ArtemisGradingPreferencesPage extends FieldEditorPreferencePage imp
 		artemisPassword.getTextControl(this.getFieldEditorParent()).setEchoChar('*');
 		
 		this.userPrefersLargePenaltyText = new BooleanFieldEditor(PreferenceConstants.PREFERS_LARGE_PENALTY_TEXT_PATH, "Use larger multi-line-text-box for custom penaltys", this.getFieldEditorParent());
+		this.userPrefersTextWrappingInPenaltyText = new BooleanFieldEditor(PreferenceConstants.PREFERS_TEXT_WRAPPING_IN_PENALTY_TEXT_PATH, "Allow text-wrapping in multiline-text-box", this.getFieldEditorParent());
 
 		this.addField(this.absoluteConfigPath);
 		this.addField(this.relativeConfigPath);
@@ -67,6 +69,7 @@ public class ArtemisGradingPreferencesPage extends FieldEditorPreferencePage imp
 		this.addField(artemisUser);
 		this.addField(artemisPassword);
 		this.addField(this.userPrefersLargePenaltyText);
+		this.addField(this.userPrefersTextWrappingInPenaltyText);
 
 	}
 

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/preferences/PreferenceInitializer.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/preferences/PreferenceInitializer.java
@@ -21,6 +21,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		store.setDefault(PreferenceConstants.ARTEMIS_USER, "");
 		store.setDefault(PreferenceConstants.ARTEMIS_PASSWORD, "");
 		store.setDefault(PreferenceConstants.PREFERS_LARGE_PENALTY_TEXT_PATH, "false");
+		store.setDefault(PreferenceConstants.PREFERS_TEXT_WRAPPING_IN_PENALTY_TEXT_PATH, "false");
 	}
 
 }


### PR DESCRIPTION
As requested in #143 I added a config-option to enable line-wrapping for custom penalty-texts.