### PR TITLE
`Bugfix`: Prevent duplicated annotations when reopening a cloned submission

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/ArtemisController.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/ArtemisController.java
@@ -77,7 +77,9 @@ public class ArtemisController extends AbstractController implements IArtemisCon
 	private boolean existsAndNotify(File file) {
 		if (file.exists()) {
 			this.warn("Project " + file.getName() + " could not be cloned since the workspace "
-					+ "already contains a project with that name. Please delete it and retry.");
+					+ "already contains a project with that name. " + System.lineSeparator()
+					+ "Trying to load and merge previously created annotations. Please double-check them before submitting the assessment! " + System.lineSeparator()
+					+ "If you want to start again from skretch, please delete the project and retry.");
 			return true;
 		}
 		return false;

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/controllers/AssessmentViewController.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/controllers/AssessmentViewController.java
@@ -129,7 +129,7 @@ public class AssessmentViewController {
 		try {
 			IMarker[] markers = AssessmentUtilities.getFile(annotation.getClassFilePath(), this.systemwideController.getCurrentProjectName()).findMarkers(null, false, 100);
 			for (IMarker marker : markers) {
-				if (annotation.getUUID().equals((String) marker.getAttribute("annotationID"))) {
+				if (annotation.getUUID().equals(marker.getAttribute("annotationID"))) {
 					return true;
 				}
 			}

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/controllers/AssessmentViewController.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/controllers/AssessmentViewController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.ITextSelection;
 
 import edu.kit.kastel.eclipse.grading.view.activator.Activator;
@@ -111,9 +112,32 @@ public class AssessmentViewController {
 
 	/**
 	 * creates markers for current annotations in the backend
+	 * The method will prevent duplicated markers resulting from 
+	 * having them in the local project and on the server.
 	 */
 	public void createAnnotationsMarkers() {
-		this.getAnnotations().forEach(this::createMarkerForAnnotation);
+		this.getAnnotations().stream().filter(annotation -> !isAnnotationPresent(annotation)).forEach(this::createMarkerForAnnotation);
+	}
+	
+	/**
+	 * Checks whether the given annotation is present in the currently opened project 
+	 * (An annotation is identified by its UUID)
+	 * @param annotation the annotation to check
+	 * @return true if the annotation is present, false if not
+	 */
+	private boolean isAnnotationPresent(IAnnotation annotation) {
+		try {
+			IMarker[] markers = AssessmentUtilities.getFile(annotation.getClassFilePath(), this.systemwideController.getCurrentProjectName()).findMarkers(null, false, 100);
+			for (IMarker marker : markers) {
+				if (annotation.getUUID().equals((String) marker.getAttribute("annotationID"))) {
+					return true;
+				}
+			}
+			return false;
+		} catch (CoreException e) {
+			// If the project (or file) can not be loaded the annotation is definitely not present 
+			return false;
+		}
 	}
 
 	private void createMarkerForAnnotation(IAnnotation annotation) {


### PR DESCRIPTION
As described in #144 cloning a submission present in the workspace will result in a warning but also duplicated annotations.
I added a filter to the code generating the new annotations to only create annotations that are not already present in the local code.
This feature can help a lot if your eclipse closes for any reason and you just want to continue working right where you stopped.

However, the code will never get pulled again from version-control. Therefore any change to the code will not be updated on the local disk. This shouldn't be any issue hence after a correction started, there shouldn't be any changes to the students repository.