### PR TITLE
`General/Bugfix` fix null-Feedbacks

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.client/src/edu/kit/kastel/sdq/eclipse/grading/client/mappings/lock/LockResult.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.client/src/edu/kit/kastel/sdq/eclipse/grading/client/mappings/lock/LockResult.java
@@ -2,6 +2,7 @@ package edu.kit.kastel.sdq.eclipse.grading.client.mappings.lock;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -29,7 +30,7 @@ public class LockResult implements ILockResult {
 				: previousAssessmentresults.get(previousAssessmentresults.size() - 1);
 
 		if (latestResult != null) {
-			this.latestFeedback.addAll(latestResult.getFeedbacks());
+			latestResult.getFeedbacks().stream().filter(Objects::nonNull).forEach(this.latestFeedback::add);
 		}
 	}
 

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationDeserializer.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationDeserializer.java
@@ -42,6 +42,9 @@ public class AnnotationDeserializer {
 	 */
 	public List<IAnnotation> deserialize(List<Feedback> feedbacks) throws IOException {
 		final List<Feedback> matchingFeedbacks = feedbacks.stream().filter(feedback -> {
+			if (feedback == null) {
+				return false;
+			}
 			String text = feedback.getText();
 			return text != null && text.equals(FEEDBACK_TEXT);
 		}).collect(Collectors.toList());

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationMapper.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationMapper.java
@@ -7,6 +7,7 @@ import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -72,6 +73,7 @@ public class AnnotationMapper {
 		final List<Feedback> result = new ArrayList<>(this.getFilteredPreexistentFeedbacks(FeedbackType.AUTOMATIC));
 		result.addAll(submissionIsInvalid ? this.calculateInvalidManualFeedback() : this.calculateManualFeedbacks());
 		result.addAll(this.calculateAnnotationSerialitationAsFeedbacks());
+		result.removeIf(Objects::isNull);
 		return result;
 	}
 

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationMapper.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationMapper.java
@@ -146,7 +146,7 @@ public class AnnotationMapper {
 				allFeedbacks.stream().filter(Objects::nonNull).filter(feedback -> feedback.getFeedbackType() == FeedbackType.AUTOMATIC).collect(Collectors.toList());
 
 		final List<Feedback> tests = autoFeedbacks.stream().filter(f -> f.getReference() == null).collect(Collectors.toList());
-		long positiveTests = tests.stream().filter(Feedback::getPositive).count();
+		long positiveTests = tests.stream().filter(feedback -> feedback.getPositive() != null && feedback.getPositive()).count();
 		long numberOfTests = tests.size();
 
 		// ENHANCE We may add "Issues" as text here iff activated ?

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationMapper.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationMapper.java
@@ -143,7 +143,7 @@ public class AnnotationMapper {
 
 	private String calculateResultString(final List<Feedback> allFeedbacks, final double absoluteScore) {
 		final List<Feedback> autoFeedbacks = //
-				allFeedbacks.stream().filter(feedback -> feedback.getFeedbackType() == FeedbackType.AUTOMATIC).collect(Collectors.toList());
+				allFeedbacks.stream().filter(Objects::nonNull).filter(feedback -> feedback.getFeedbackType() == FeedbackType.AUTOMATIC).collect(Collectors.toList());
 
 		final List<Feedback> tests = autoFeedbacks.stream().filter(f -> f.getReference() == null).collect(Collectors.toList());
 		long positiveTests = tests.stream().filter(Feedback::getPositive).count();

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationMapper.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationMapper.java
@@ -33,6 +33,9 @@ public class AnnotationMapper {
 	// keep this up to date with
 	// https://github.com/ls1intum/Artemis/blob/develop/src/main/java/de/tum/in/www1/artemis/config/Constants.java#L121
 	private static final int FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS = 5000;
+	
+	// amount of space to leave in the feedback-text
+	private static final int FEEDBACK_DETAIL_SAFETY_MARGIN = 50;
 
 	private static final NumberFormat nf = new DecimalFormat("##.###", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
 
@@ -257,14 +260,14 @@ public class AnnotationMapper {
 		
 		List<String> feedbackTexts = new LinkedList<>();
 		
-		if (lines.size() == 0) {
+		if (lines.isEmpty()) {
 			return List.of();
 		}
 		
 		String text = annotationHeadline + " (annotation " + 1 + ")";
 		
 		for (int i = 0; i < lines.size(); i++) {
-			if (text.length() + lines.get(i).length() >= FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS - annotationHeadline.length() - 50) {
+			if (text.length() + lines.get(i).length() >= FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS - annotationHeadline.length() - FEEDBACK_DETAIL_SAFETY_MARGIN) {
 				feedbackTexts.add(text);
 				text = annotationHeadline + " (annotation " + (feedbackTexts.size() + 1) + ")";
 			}

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/observers/ViewAlertObserver.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/observers/ViewAlertObserver.java
@@ -1,5 +1,7 @@
 package edu.kit.kastel.eclipse.grading.view.observers;
 
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.dialogs.MessageDialog;
 
 import edu.kit.kastel.eclipse.grading.view.utilities.AssessmentUtilities;
@@ -11,19 +13,24 @@ import edu.kit.kastel.sdq.eclipse.grading.api.controller.IAlertObserver;
  *
  */
 public class ViewAlertObserver implements IAlertObserver {
-
+	
+	private static final ILog log = Platform.getLog(ViewAlertObserver.class); 
+	
 	@Override
-	public void error(String errorMsg, Throwable cause) {
+	public void error(String errorMsg, Throwable cause) {	
+		log.error(errorMsg, cause);
 		MessageDialog.openError(AssessmentUtilities.getWindowsShell(), "Error", errorMsg);
 	}
 
 	@Override
 	public void info(String infoMsg) {
+		log.info(infoMsg);
 		MessageDialog.openInformation(AssessmentUtilities.getWindowsShell(), "Info", infoMsg);
 	}
 
 	@Override
 	public void warn(String warningMsg) {
+		log.warn(warningMsg);
 		MessageDialog.openWarning(AssessmentUtilities.getWindowsShell(), "Warning", warningMsg);
 	}
 


### PR DESCRIPTION
As described in #151 weird things go on where the feedbacks will contain null-values which introduce some weird bugs in the plugin.
I'm currently trying to find all the issues that (might) break by null-Feedbacks, however it's not realy clear where exactly everything breaks. 
To increase chances of success, I also added proper logging to `ViewAlertObserver` in order to get more information about the real error happening somewhere.

I'm realy interested in your oppinions whether we should directly add this logging to production or we should first investigate more before.

Also I'd realy like to hear your oppinions about where even more null-checks might be necessary.