### PR TITLE
updated tycho version

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extensions>
 	<extension>
-		<groupId>org.eclipse.tycho.extras</groupId>
-		<artifactId>tycho-pomless</artifactId>
-		<version>2.1.0</version>
+		<groupId>org.eclipse.tycho</groupId>
+		<artifactId>tycho-build</artifactId>
+		<version>2.7.0</version>
 	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <xtext.version>2.19.0</xtext.version>
-        <tycho.version>2.1.0</tycho.version>
+        <tycho.version>2.7.0</tycho.version>
         <spotless.version>2.20.2</spotless.version>
     </properties>
 


### PR DESCRIPTION
* switch to new tycho version 2.7
* changed pomless to new naming schema, [see](https://github.com/eclipse/tycho/blob/master/RELEASE_NOTES.md#tycho-pomless-will-become-a-tycho-core-extension)
* This should enable us to use Java 17 in the build process