### PR TITLE
Added update of description of custom penalty-markers.

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/utilities/AssessmentUtilities.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/utilities/AssessmentUtilities.java
@@ -223,6 +223,19 @@ public final class AssessmentUtilities {
 		}
 	}
 
+	public static void updateMarkerMessage(IMarker marker, String newMessage, Double newPenalty) throws ArtemisClientException {
+		try {
+			marker.setAttribute(AssessmentUtilities.MARKER_ATTRIBUTE_CUSTOM_MESSAGE, newMessage);
+			marker.setAttribute(AssessmentUtilities.MARKER_ATTRIBUTE_CUSTOM_PENALTY, newPenalty.toString());
+			Integer startLine = (Integer) marker.getAttribute(AssessmentUtilities.MARKER_ATTRIBUTE_START);
+			Integer endLine = (Integer) marker.getAttribute(AssessmentUtilities.MARKER_ATTRIBUTE_END);
+
+			marker.setAttribute(IMarker.MESSAGE, AssessmentUtilities.createMarkerTooltipForCustomButton(startLine, endLine, newMessage, newPenalty));
+		} catch (Exception e) {
+			throw new ArtemisClientException(e.getMessage());
+		}
+	}
+
 	/**
 	 * Checks whether the given annotation is present in the currently opened
 	 * project (An annotation is identified by its UUID)

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/listeners/AssessmentMarkerViewDoubleClickListener.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/listeners/AssessmentMarkerViewDoubleClickListener.java
@@ -13,6 +13,7 @@ import edu.kit.kastel.eclipse.common.view.utilities.AssessmentUtilities;
 import edu.kit.kastel.eclipse.grading.view.activator.Activator;
 import edu.kit.kastel.eclipse.grading.view.assessment.ArtemisGradingView;
 import edu.kit.kastel.eclipse.grading.view.assessment.CustomButtonDialog;
+import edu.kit.kastel.sdq.eclipse.common.api.ArtemisClientException;
 import edu.kit.kastel.sdq.eclipse.common.api.model.IAnnotation;
 
 public class AssessmentMarkerViewDoubleClickListener implements IDoubleClickListener {
@@ -54,13 +55,12 @@ public class AssessmentMarkerViewDoubleClickListener implements IDoubleClickList
 					String newMessage = dialog.getCustomMessage();
 					Double newPenalty = annotation.getMistakeType().isCustomPenalty() ? dialog.getCustomPenalty() : annotation.getCustomPenalty().orElse(0d);
 
-					item.getMarker().setAttribute(AssessmentUtilities.MARKER_ATTRIBUTE_CUSTOM_MESSAGE, newMessage);
-					item.getMarker().setAttribute(AssessmentUtilities.MARKER_ATTRIBUTE_CUSTOM_PENALTY, newPenalty.toString());
+					AssessmentUtilities.updateMarkerMessage(item.getMarker(), newMessage, newPenalty);
 
 					Activator.getDefault().getSystemwideController().getCurrentAssessmentController().modifyAnnotation(annotation.getUUID(), newMessage,
 							newPenalty);
 					this.gradingView.updatePenalties();
-				} catch (CoreException e) {
+				} catch (CoreException | ArtemisClientException e) {
 					e.printStackTrace();
 				}
 			}


### PR DESCRIPTION
Fix for "After changing the points in a custom deduction. The status bar (not sure how the element is called) shows still the old points. However, internally it uses already correct points"

Fixes https://github.com/kit-sdq/programming-lecture-eclipse-artemis/issues/193#issuecomment-1111056043