### PR TITLE
Load backlog automatically

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
@@ -212,9 +212,6 @@ public class ArtemisGradingView extends ViewPart {
 
 	private void addSelectionListenerForFilterCombo(Combo backlogCombo, Combo filterCombo) {
 		filterCombo.addListener(SWT.Selection, e -> {
-			if (backlogCombo.getItemCount() == 0) {
-				return;
-			}
 			this.fillBacklogComboWithData(backlogCombo, filterCombo);
 		});
 	}


### PR DESCRIPTION
Closes https://github.com/kit-sdq/programming-lecture-eclipse-artemis/issues/145

I'm quite confused why the original implementation had the check I removed in the fist place. If somebody remembers the reason, please tell me.

I've tested the change and it worked for me. Now the entries for the backlog will be loaded when the filter setting is changed.