### PR TITLE
Added StackingPenaltyRule

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/sdq/eclipse/common/core/config/PenaltyRuleDeserializer.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/sdq/eclipse/common/core/config/PenaltyRuleDeserializer.java
@@ -2,6 +2,7 @@
 package edu.kit.kastel.sdq.eclipse.common.core.config;
 
 import java.io.IOException;
+import java.util.function.Function;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -34,14 +35,9 @@ public class PenaltyRuleDeserializer extends StdDeserializer<PenaltyRule> {
 	public enum PenaltyRuleType {
 		// Need to add a new enum value with a short Name (that must be used in the
 		// config file) and a constructor based on the json node.
-		THRESHOLD_PENALTY_RULE_TYPE(ThresholdPenaltyRule.SHORT_NAME,
-				penaltyRuleNode -> new ThresholdPenaltyRule(penaltyRuleNode.get("threshold").asInt(), penaltyRuleNode.get("penalty").asDouble())),
-		STACKING_PENATLY_RULE_TYPE(StackingPenaltyRule.SHORT_NAME, penaltyRuleNode -> new StackingPenaltyRule(penaltyRuleNode.get("penalty").asDouble())),
-		CUSTOM_PENALTY_RULE_TYPE(CustomPenaltyRule.SHORT_NAME, penaltyRuleNode -> new CustomPenaltyRule()),;
-
-		interface Constructor {
-			PenaltyRule construct(final JsonNode penaltyRuleNode);
-		}
+		THRESHOLD_PENALTY_RULE_TYPE(ThresholdPenaltyRule.SHORT_NAME, ThresholdPenaltyRule::new), //
+		STACKING_PENATLY_RULE_TYPE(StackingPenaltyRule.SHORT_NAME, StackingPenaltyRule::new), //
+		CUSTOM_PENALTY_RULE_TYPE(CustomPenaltyRule.SHORT_NAME, CustomPenaltyRule::new);
 
 		public static PenaltyRuleType fromShortName(String shortName) {
 			for (PenaltyRuleType penaltyRuleType : PenaltyRuleType.values()) {
@@ -52,17 +48,17 @@ public class PenaltyRuleDeserializer extends StdDeserializer<PenaltyRule> {
 			return null;
 		}
 
-		private Constructor constructor;
+		private final Function<JsonNode, PenaltyRule> constructor;
 
-		private String shortName;
+		private final String shortName;
 
-		PenaltyRuleType(final String shortName, final Constructor constructor) {
+		PenaltyRuleType(final String shortName, final Function<JsonNode, PenaltyRule> constructor) {
 			this.shortName = shortName;
 			this.constructor = constructor;
 		}
 
 		public PenaltyRule construct(final JsonNode penaltyRuleNode) {
-			return this.constructor.construct(penaltyRuleNode);
+			return this.constructor.apply(penaltyRuleNode);
 		}
 
 		public String getShortName() {
@@ -85,7 +81,5 @@ public class PenaltyRuleDeserializer extends StdDeserializer<PenaltyRule> {
 			return penaltyRuleType.construct(penaltyRuleNode);
 		}
 		throw new IOException("No PenaltyRule Subclass defined for penaltyRule " + penaltyRuleShortName);
-
 	}
-
 }

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/sdq/eclipse/common/core/config/PenaltyRuleDeserializer.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/sdq/eclipse/common/core/config/PenaltyRuleDeserializer.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
 import edu.kit.kastel.sdq.eclipse.common.core.model.CustomPenaltyRule;
 import edu.kit.kastel.sdq.eclipse.common.core.model.PenaltyRule;
+import edu.kit.kastel.sdq.eclipse.common.core.model.StackingPenaltyRule;
 import edu.kit.kastel.sdq.eclipse.common.core.model.ThresholdPenaltyRule;
 
 /**
@@ -35,7 +36,8 @@ public class PenaltyRuleDeserializer extends StdDeserializer<PenaltyRule> {
 		// config file) and a constructor based on the json node.
 		THRESHOLD_PENALTY_RULE_TYPE(ThresholdPenaltyRule.SHORT_NAME,
 				penaltyRuleNode -> new ThresholdPenaltyRule(penaltyRuleNode.get("threshold").asInt(), penaltyRuleNode.get("penalty").asDouble())),
-		CUSTOM_PENALTY_RULE_TYPE(CustomPenaltyRule.SHORT_NAME, penaltyRuleNode -> new CustomPenaltyRule());
+		STACKING_PENATLY_RULE_TYPE(StackingPenaltyRule.SHORT_NAME, penaltyRuleNode -> new StackingPenaltyRule(penaltyRuleNode.get("penalty").asDouble())),
+		CUSTOM_PENALTY_RULE_TYPE(CustomPenaltyRule.SHORT_NAME, penaltyRuleNode -> new CustomPenaltyRule()),;
 
 		interface Constructor {
 			PenaltyRule construct(final JsonNode penaltyRuleNode);

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/sdq/eclipse/common/core/model/CustomPenaltyRule.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/sdq/eclipse/common/core/model/CustomPenaltyRule.java
@@ -3,6 +3,8 @@ package edu.kit.kastel.sdq.eclipse.common.core.model;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import edu.kit.kastel.sdq.eclipse.common.api.model.IAnnotation;
 
 public class CustomPenaltyRule extends PenaltyRule {
@@ -10,8 +12,8 @@ public class CustomPenaltyRule extends PenaltyRule {
 	private static final String DISPLAY_NAME = "Custom Penalty";
 	public static final String SHORT_NAME = "customPenalty";
 
-	public CustomPenaltyRule() {
-		// a comment explaining why this method is empty
+	public CustomPenaltyRule(JsonNode penaltyRuleNode) {
+		// No need for custom configurations.
 	}
 
 	@Override

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/sdq/eclipse/common/core/model/StackingPenaltyRule.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/sdq/eclipse/common/core/model/StackingPenaltyRule.java
@@ -3,6 +3,8 @@ package edu.kit.kastel.sdq.eclipse.common.core.model;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import edu.kit.kastel.sdq.eclipse.common.api.model.IAnnotation;
 
 public class StackingPenaltyRule extends PenaltyRule {
@@ -14,8 +16,8 @@ public class StackingPenaltyRule extends PenaltyRule {
 	// rounding issues happen)
 	private int penalty;
 
-	public StackingPenaltyRule(double penalty) {
-		this.penalty = (int) (penalty * 10);
+	public StackingPenaltyRule(JsonNode penaltyRuleNode) {
+		this.penalty = (int) (penaltyRuleNode.get("penalty").asDouble() * 10);
 	}
 
 	@Override

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/sdq/eclipse/common/core/model/StackingPenaltyRule.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/sdq/eclipse/common/core/model/StackingPenaltyRule.java
@@ -1,0 +1,52 @@
+/* Licensed under EPL-2.0 2022. */
+package edu.kit.kastel.sdq.eclipse.common.core.model;
+
+import java.util.List;
+
+import edu.kit.kastel.sdq.eclipse.common.api.model.IAnnotation;
+
+public class StackingPenaltyRule extends PenaltyRule {
+
+	private static final String DISPLAY_NAME = "Stacking Penalty";
+	public static final String SHORT_NAME = "stackingPenalty";
+
+	// Penalty stored with decimal-point shifted one to the right (make sure no
+	// rounding issues happen)
+	private int penalty;
+
+	public StackingPenaltyRule(double penalty) {
+		this.penalty = (int) (penalty * 10);
+	}
+
+	@Override
+	public double calculatePenalty(List<IAnnotation> annotations) {
+		return (annotations.size() * this.penalty) / 10.0;
+	}
+
+	@Override
+	public String getDisplayName() {
+		return DISPLAY_NAME;
+	}
+
+	@Override
+	public String getShortName() {
+		return SHORT_NAME;
+	}
+
+	@Override
+	public String getTooltip(List<IAnnotation> annotations) {
+		double penaltyValue = this.calculatePenalty(annotations);
+		return penaltyValue + " points [" + annotations.size() + " annotations made]";
+	}
+
+	@Override
+	public String toString() {
+		return "StackingPenaltyRule [penalty=" + this.penalty / 10.0 + " per annotation]";
+	}
+
+	@Override
+	protected boolean isCustomPenalty() {
+		return false;
+	}
+
+}

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/sdq/eclipse/common/core/model/StackingPenaltyRule.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/sdq/eclipse/common/core/model/StackingPenaltyRule.java
@@ -3,8 +3,6 @@ package edu.kit.kastel.sdq.eclipse.common.core.model;
 
 import java.util.List;
 
-import org.eclipse.jgit.annotations.Nullable;
-
 import com.fasterxml.jackson.databind.JsonNode;
 
 import edu.kit.kastel.sdq.eclipse.common.api.model.IAnnotation;
@@ -18,7 +16,6 @@ public class StackingPenaltyRule extends PenaltyRule {
 	// rounding issues happen)
 	private int penalty;
 
-	@Nullable
 	private Integer maxUses = null; // null => no limit
 
 	public StackingPenaltyRule(JsonNode penaltyRuleNode) {

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/sdq/eclipse/common/core/model/ThresholdPenaltyRule.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/sdq/eclipse/common/core/model/ThresholdPenaltyRule.java
@@ -3,6 +3,8 @@ package edu.kit.kastel.sdq.eclipse.common.core.model;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import edu.kit.kastel.sdq.eclipse.common.api.model.IAnnotation;
 
 /**
@@ -17,9 +19,9 @@ public class ThresholdPenaltyRule extends PenaltyRule {
 	private int threshold;
 	private double penalty;
 
-	public ThresholdPenaltyRule(int threshold, double penalty) {
-		this.threshold = threshold;
-		this.penalty = penalty;
+	public ThresholdPenaltyRule(JsonNode penaltyRuleNode) {
+		this.threshold = penaltyRuleNode.get("threshold").asInt();
+		this.penalty = penaltyRuleNode.get("penalty").asDouble();
 	}
 
 	@Override


### PR DESCRIPTION
Added option to create assessment-buttons which will apply their penalty on every click.

A new PanaltyRule is introduced for this. Sample configuration:
```json
"penaltyRule": {
  "shortName": "stackingPenalty",
  "penalty": 0.5,
  "maxUses": 4 
}
```
Note: `maxUses` can be left out or explicitly set to `null` to remove the cap for the stackingPenalty.