### PR TITLE
Added default-preferences for eclipse JDT

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.common.view/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.view/META-INF/MANIFEST.MF
@@ -11,7 +11,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jface.text,
  edu.kit.kastel.sdq.eclipse.common.api,
  edu.kit.kastel.sdq.eclipse.common.client,
- edu.kit.kastel.sdq.eclipse.common.core
+ edu.kit.kastel.sdq.eclipse.common.core,
+ org.eclipse.jdt.core
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: edu.kit.kastel.eclipse.common.view.activator.CommonActivator

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/activator/CommonActivator.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/activator/CommonActivator.java
@@ -1,13 +1,11 @@
 /* Licensed under EPL-2.0 2022. */
 package edu.kit.kastel.eclipse.common.view.activator;
 
-import org.eclipse.ui.editors.text.EditorsUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
-import org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants;
 import org.osgi.framework.BundleContext;
 
 import edu.kit.kastel.eclipse.common.view.languages.LanguageSettings;
-import edu.kit.kastel.sdq.eclipse.common.api.PreferenceConstants;
+import edu.kit.kastel.eclipse.common.view.utilities.PreferenceTweaker;
 
 /**
  * The activator class controls the plug-in life cycle
@@ -31,7 +29,7 @@ public class CommonActivator extends AbstractUIPlugin {
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
 		plugin = this;
-		this.tweakPreferences();
+		PreferenceTweaker.tweakPreferences();
 		LanguageSettings.updateI18N();
 	}
 
@@ -48,16 +46,6 @@ public class CommonActivator extends AbstractUIPlugin {
 	 */
 	public static CommonActivator getDefault() {
 		return plugin;
-	}
-
-	private void tweakPreferences() {
-		var preferences = this.getPreferenceStore();
-		if (!preferences.getBoolean(PreferenceConstants.GENERAL_OVERRIDE_DEFAULT_PREFERENCES)) {
-			return;
-		}
-
-		// Enable Line Numbers by default
-		EditorsUI.getPreferenceStore().setValue(AbstractDecoratedTextEditorPreferenceConstants.EDITOR_LINE_NUMBER_RULER, true);
 	}
 
 }

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/utilities/PreferenceTweaker.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/utilities/PreferenceTweaker.java
@@ -1,0 +1,136 @@
+/* Licensed under EPL-2.0 2022. */
+package edu.kit.kastel.eclipse.common.view.utilities;
+
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.ui.editors.text.EditorsUI;
+import org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants;
+import org.osgi.service.prefs.BackingStoreException;
+
+import edu.kit.kastel.eclipse.common.view.activator.CommonActivator;
+import edu.kit.kastel.sdq.eclipse.common.api.PreferenceConstants;
+
+@SuppressWarnings("unused") // as not all constants are used
+public final class PreferenceTweaker {
+
+	private static final ILog log = Platform.getLog(PreferenceTweaker.class);
+
+	private static final String JDT_IGNORE = "ignore";
+	private static final String JDT_INFO = "info";
+	private static final String JDT_WARNING = "warning";
+	private static final String JDT_ERROR = "error";
+	private static final String JDT_ENABLED = "enabled";
+	private static final String JDT_DISABLED = "disabled";
+
+	private PreferenceTweaker() {
+		throw new IllegalAccessError();
+	}
+
+	public static void tweakPreferences() {
+		var preferences = CommonActivator.getDefault().getPreferenceStore();
+		if (!preferences.getBoolean(PreferenceConstants.GENERAL_OVERRIDE_DEFAULT_PREFERENCES)) {
+			return;
+		}
+
+		log.info("Tweaking default eclipse preferences");
+
+		tweakEditorPreferences();
+		tweakJdtPreferences();
+	}
+
+	private static void tweakEditorPreferences() {
+		var editorPreferences = EditorsUI.getPreferenceStore();
+
+		// Enable Line Numbers by default
+		editorPreferences.setValue(AbstractDecoratedTextEditorPreferenceConstants.EDITOR_LINE_NUMBER_RULER, true);
+	}
+
+	private static void tweakJdtPreferences() {
+		// Modify problem severity
+		// Full list can be found here:
+		// https://git.eclipse.org/c/platform/eclipse.platform.swt.git/plain/examples/org.eclipse.swt.examples.browser.demos/.settings/org.eclipse.jdt.core.prefs
+
+		var jdtPreferenceNode = InstanceScope.INSTANCE.getNode(JavaCore.PLUGIN_ID);
+
+		//
+		// Not required for normal grading
+		//
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_MISSING_SERIAL_VERSION, JDT_IGNORE);
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_POTENTIALLY_MISSING_STATIC_ON_METHOD, JDT_IGNORE);
+
+		//
+		// Probably bugs
+		//
+		// variable hides another variable
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_FIELD_HIDING, JDT_INFO);
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_LOCAL_VARIABLE_HIDING, JDT_WARNING);
+
+		// access to static member via object-reference is discouraged
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_INDIRECT_STATIC_ACCESS, JDT_WARNING);
+
+		// method-parameters should not be re-assigned
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_PARAMETER_ASSIGNMENT, JDT_WARNING);
+
+		// show locations of auto-boxing (as unboxing can cause unexpected
+		// NullPointerExceptions)
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_AUTOBOXING, JDT_INFO);
+
+		// closeables should be closed the intended way
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_UNCLOSED_CLOSEABLE, JDT_INFO);
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_EXPLICITLY_CLOSED_AUTOCLOSEABLE, JDT_INFO);
+
+		// every part of the code should be reachable
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_DEAD_CODE, JDT_WARNING);
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_DEAD_CODE_IN_TRIVIAL_IF_STATEMENT, JDT_WARNING);
+
+		// probably wrong variable-names used
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_COMPARING_IDENTICAL, JDT_WARNING);
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_POSSIBLE_ACCIDENTAL_BOOLEAN_ASSIGNMENT, JDT_WARNING);
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_UNLIKELY_EQUALS_ARGUMENT_TYPE, JDT_WARNING);
+
+		//
+		// style
+		//
+		// every statement should contain code
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_EMPTY_STATEMENT, JDT_WARNING);
+		// Overriding equals without hashCode is discouraged
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_MISSING_HASHCODE_METHOD, JDT_INFO);
+
+		// if a method is used like a static method, it should be one
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_MISSING_STATIC_ON_METHOD, JDT_INFO);
+
+		// created objects may be used. Otherwise they are useless
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_UNUSED_OBJECT_ALLOCATION, JDT_WARNING);
+
+		// encourage the use of the diamond-operator
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_REDUNDANT_TYPE_ARGUMENTS, JDT_INFO);
+
+		// only exceptions thrown in a method should be declared
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_UNUSED_DECLARED_THROWN_EXCEPTION, JDT_WARNING);
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_UNUSED_DECLARED_THROWN_EXCEPTION_WHEN_OVERRIDING, JDT_DISABLED);
+
+		// only required parameters should be passed to a method
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_UNUSED_PARAMETER, JDT_WARNING);
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_UNUSED_PARAMETER_WHEN_IMPLEMENTING_ABSTRACT, JDT_DISABLED);
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_UNUSED_PARAMETER_WHEN_OVERRIDING_CONCRETE, JDT_DISABLED);
+
+		// it should be obvious what parameter is passed to varargs
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_VARARGS_ARGUMENT_NEED_CAST, JDT_ERROR);
+
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_REDUNDANT_NULL_CHECK, JDT_INFO);
+
+		// disable the use of @SupressWarnings
+		jdtPreferenceNode.put(JavaCore.COMPILER_PB_SUPPRESS_WARNINGS, JDT_DISABLED);
+
+		// save and load the modified preferences
+		try {
+			jdtPreferenceNode.sync();
+			jdtPreferenceNode.flush();
+		} catch (BackingStoreException e) {
+			log.warn("Could not save modified eclipse preferences.", e);
+		}
+	}
+
+}


### PR DESCRIPTION
I've added some preferences for eclipse JDT.
The severities chosen right now are pretty much based on 
1) my own oppinion
2) the "Programmieren Wiki"
3) best-practices in general

Those should definetly be discussed, however I would assume I did not made unreasonable decisions.

Note: This feature should be tested and feedback by the tutors should be gathered. If some warnings are annoying, we might consider to provide different configurations for student and grading edition :)