### PR TITLE
Fixed TestDetailsDialog

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/ui/AbstractResultTabCompositeController.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/ui/AbstractResultTabCompositeController.java
@@ -1,12 +1,13 @@
 /* Licensed under EPL-2.0 2022. */
 package edu.kit.kastel.eclipse.common.view.ui;
 
+import static edu.kit.kastel.eclipse.common.view.languages.LanguageSettings.I18N;
+
 import java.util.Locale;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.TabFolder;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
@@ -14,8 +15,6 @@ import org.eclipse.swt.widgets.TableItem;
 import edu.kit.kastel.eclipse.common.api.artemis.mapping.Feedback;
 import edu.kit.kastel.eclipse.common.api.artemis.mapping.IExercise;
 import edu.kit.kastel.eclipse.common.view.utilities.UIUtilities;
-
-import static edu.kit.kastel.eclipse.common.view.languages.LanguageSettings.I18N;
 
 abstract class AbstractResultTabCompositeController extends AbstractResultTabComposite {
 	private static final String CHECK_MARK_IN_UTF8 = "\u2713";
@@ -89,11 +88,9 @@ abstract class AbstractResultTabCompositeController extends AbstractResultTabCom
 		if (selectedFeedback == null) {
 			return;
 		}
-		Shell s = new Shell(Display.getDefault());
-		s.setMinimumSize(500, 500);
 		if (selectedFeedback.getDetailText() != null) {
 			var text = item.getText(0);
-			new TestDetailsDialog(s, text, selectedFeedback.getDetailText()).open();
+			new TestDetailsDialog(text, selectedFeedback.getDetailText()).open();
 		}
 	}
 

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/ui/TestDetailsDialog.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/ui/TestDetailsDialog.java
@@ -20,8 +20,8 @@ class TestDetailsDialog extends Dialog {
 	private String testName;
 	private String testDetails;
 
-	public TestDetailsDialog(Shell parent, String testName, String testDetails) {
-		super(parent);
+	public TestDetailsDialog(String testName, String testDetails) {
+		super((Shell) null);
 		this.setShellStyle(SWT.DIALOG_TRIM | SWT.RESIZE | SWT.MODELESS | SWT.ON_TOP);
 		this.testName = testName;
 		this.testDetails = testDetails;


### PR DESCRIPTION
The TestDetailsDialog broke after I fixed it last time, because we decided to use ON_TOP, which seems to break MODELESS dialogs with a parent.
I've removed the parrent-shell, now it should work as expected.

@dfuchss @majuwa can you validate this on your linux machines? For me it worked on my test machine.