### PR TITLE
`Actions` Added names to workflow jobs

### DIFF
--- a/.github/workflows/bundles-build-dev.yml
+++ b/.github/workflows/bundles-build-dev.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build:
+    name: "Build to test compileability"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/full-build-pr-and-main.yml
+++ b/.github/workflows/full-build-pr-and-main.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build:
+    name: "Full build of all distributions"
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    name: "Create release for new version"
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/spotless-check-any.yml
+++ b/.github/workflows/spotless-check-any.yml
@@ -9,7 +9,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  style-check:
+    name: "Check codestyle with Spotless"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
In order to make it more obious to (new) developers which jobs are executed by which workflow, I've added some names to the jobs. They will be displayed instead of "build".

Old:
![grafik](https://user-images.githubusercontent.com/30196411/174501323-b76385c2-5be8-4ad7-81af-82b2e08d7d0f.png)
![grafik](https://user-images.githubusercontent.com/30196411/174501516-a22fa4c3-b2bc-4d9e-ae00-07dcfc3c5fda.png)


New:
![grafik](https://user-images.githubusercontent.com/30196411/174501395-741a90ea-1f34-4519-91f6-dd76e95b30d5.png)
![grafik](https://user-images.githubusercontent.com/30196411/174501518-01cc996c-047e-4a6a-bd62-e901325e06ff.png)

