### PR TITLE
Postpone file opening until after JDT has initialized itself

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
@@ -490,8 +490,7 @@ public class ArtemisGradingView extends ViewPart {
 					var explorer = AssessmentUtilities.getProjectExplorer(page);
 
 					// Expand all packages
-					var packagePaths = JDTUtilities.getAllCompilationUnits(projects[0]).stream()
-							.map(ICompilationUnit::getResource).toList();
+					var packagePaths = JDTUtilities.getAllCompilationUnits(projects[0]).stream().map(ICompilationUnit::getResource).toList();
 					Display.getDefault().asyncExec(() -> {
 						// Select all packages to reveal them...
 						explorer.ifPresent(e -> e.selectReveal(new StructuredSelection(packagePaths)));
@@ -499,13 +498,11 @@ public class ArtemisGradingView extends ViewPart {
 						explorer.ifPresent(e -> e.selectReveal(new StructuredSelection()));
 					});
 
-					String openPreference = CommonActivator.getDefault().getPreferenceStore()
-							.getString(PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START);
+					String openPreference = CommonActivator.getDefault().getPreferenceStore().getString(PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START);
 
 					// Open all types if desired
 					if (openPreference.equals(PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START_ALL)) {
-						JDTUtilities.getAllCompilationUnits(projects[0])
-								.forEach(c -> AssessmentUtilities.openJavaElement(c, page));
+						JDTUtilities.getAllCompilationUnits(projects[0]).forEach(c -> AssessmentUtilities.openJavaElement(c, page));
 					}
 
 					// Open/focus the main class
@@ -517,8 +514,7 @@ public class ArtemisGradingView extends ViewPart {
 
 							// ... and focus it in the package explorer
 							Display.getDefault().asyncExec(() -> {
-								explorer.ifPresent(
-										e -> e.selectReveal(new StructuredSelection(mainType.get().getResource())));
+								explorer.ifPresent(e -> e.selectReveal(new StructuredSelection(mainType.get().getResource())));
 							});
 						} else {
 							LOG.warn("No main class found");

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
@@ -11,7 +11,10 @@ import java.util.Map;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.jdt.core.ElementChangedEvent;
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IElementChangedListener;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
@@ -479,43 +482,55 @@ public class ArtemisGradingView extends ViewPart {
 		}
 
 		var page = ArtemisGradingView.this.getSite().getPage();
-		try {
-			var explorer = AssessmentUtilities.getProjectExplorer(page);
 
-			// Expand all packages
-			var packagePaths = JDTUtilities.getAllCompilationUnits(projects[0]).stream().map(ICompilationUnit::getResource).toList();
-			Display.getDefault().asyncExec(() -> {
-				// Select all packages to reveal them...
-				explorer.ifPresent(e -> e.selectReveal(new StructuredSelection(packagePaths)));
-				// ... and deselect them once they are expanded
-				explorer.ifPresent(e -> e.selectReveal(new StructuredSelection()));
-			});
+		IElementChangedListener listener = new IElementChangedListener() {
+			@Override
+			public void elementChanged(ElementChangedEvent event) {
+				try {
+					var explorer = AssessmentUtilities.getProjectExplorer(page);
 
-			String openPreference = CommonActivator.getDefault().getPreferenceStore().getString(PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START);
-
-			// Open all types if desired
-			if (openPreference.equals(PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START_ALL)) {
-				JDTUtilities.getAllCompilationUnits(projects[0]).forEach(c -> AssessmentUtilities.openJavaElement(c, page));
-			}
-
-			// Open/focus the main class
-			if (!openPreference.equals(PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START_NONE)) {
-				var mainType = JDTUtilities.findMainClass(projects[0]);
-				if (mainType.isPresent()) {
-					// Open/focus the main class in the editor...
-					AssessmentUtilities.openJavaElement(mainType.get(), page);
-
-					// ... and focus it in the package explorer
+					// Expand all packages
+					var packagePaths = JDTUtilities.getAllCompilationUnits(projects[0]).stream()
+							.map(ICompilationUnit::getResource).toList();
 					Display.getDefault().asyncExec(() -> {
-						explorer.ifPresent(e -> e.selectReveal(new StructuredSelection(mainType.get().getResource())));
+						// Select all packages to reveal them...
+						explorer.ifPresent(e -> e.selectReveal(new StructuredSelection(packagePaths)));
+						// ... and deselect them once they are expanded
+						explorer.ifPresent(e -> e.selectReveal(new StructuredSelection()));
 					});
-				} else {
-					LOG.warn("No main class found");
+
+					String openPreference = CommonActivator.getDefault().getPreferenceStore()
+							.getString(PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START);
+
+					// Open all types if desired
+					if (openPreference.equals(PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START_ALL)) {
+						JDTUtilities.getAllCompilationUnits(projects[0])
+								.forEach(c -> AssessmentUtilities.openJavaElement(c, page));
+					}
+
+					// Open/focus the main class
+					if (!openPreference.equals(PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START_NONE)) {
+						var mainType = JDTUtilities.findMainClass(projects[0]);
+						if (mainType.isPresent()) {
+							// Open/focus the main class in the editor...
+							AssessmentUtilities.openJavaElement(mainType.get(), page);
+
+							// ... and focus it in the package explorer
+							Display.getDefault().asyncExec(() -> {
+								explorer.ifPresent(
+										e -> e.selectReveal(new StructuredSelection(mainType.get().getResource())));
+							});
+						} else {
+							LOG.warn("No main class found");
+						}
+					}
+				} catch (JavaModelException e) {
+					LOG.error("JDT failure", e);
 				}
+				JavaCore.removeElementChangedListener(this);
 			}
-		} catch (JavaModelException e) {
-			LOG.error("JDT failure", e);
-		}
+		};
+		JavaCore.addElementChangedListener(listener, ElementChangedEvent.POST_CHANGE);
 	}
 
 	public boolean isPositiveFeedbackAllowed() {


### PR DESCRIPTION
<!-- Thanks for contributing to our Artemis Plugin! Before you submit your pull request, please make sure to check the boxes in our checklist. -->

### Checklist
- [x] I tested *all* changes and their related features locally or with a test instance of Artemis.
- [x] I documented the Java code using JavaDoc style.
- [x] I documented the changes in the Documentation (/docs).

### Motivation and Context
See #270. I believe that the problem is a race condition between our code and the JDT: If we try to open a Java class before the JDT has parsed the source files, the JDT gets confused and thinks that assignment/src should be part of the package declaration. However, I'm not sure if this is really what is going on here, so further testing is required. It does seem to consistently fix the problem on my machine.

### Description
Execute the code for opening packages and classes inside of a JDT resource changed listener.

### Steps for Testing
Make sure that "Open files automatically" is set to "All types" or "Main class". Then start a new assessment. Repeat this step a few times as the issue seems to be racey.
