### PR TITLE
Speedup for Github Actions by using cache and different platforms

### DIFF
--- a/.github/workflows/full-build-pr-and-main.yml
+++ b/.github/workflows/full-build-pr-and-main.yml
@@ -20,11 +20,6 @@ jobs:
 
     steps:
 
-    - name: Install build utils
-      run: |
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get update
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y eatmydata
-
     - uses: actions/checkout@v3.3.0
 
     - name: Set up JDK
@@ -47,7 +42,7 @@ jobs:
         key: cache-dist-${{github.run_id}}
 
     - name: Build with Maven
-      run: eatmydata mvn -U -B -Pproducts package
+      run: mvn -U -B -Pproducts package
 
     - name: Move Distributions
       run: |

--- a/.github/workflows/full-build-pr-and-main.yml
+++ b/.github/workflows/full-build-pr-and-main.yml
@@ -16,9 +16,15 @@ on:
 jobs:
   build:
     name: "Full build of all distributions"
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
+
+    - name: Install build utils
+      run: |
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get update
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y eatmydata
+
     - uses: actions/checkout@v3.3.0
 
     - name: Set up JDK
@@ -34,8 +40,14 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-maven-
 
+    - name: Cache Distributions
+      uses: actions/cache@v3
+      with:
+        path: ./dist
+        key: cache-dist-${{github.run_id}}
+
     - name: Build with Maven
-      run: mvn -U -B -Pproducts package
+      run: eatmydata mvn -U -B -Pproducts package
 
     - name: Move Distributions
       run: |
@@ -50,7 +62,19 @@ jobs:
         mv releng/edu.kit.kastel.sdq.eclipse.student.product/target/products/*-linux.*.aarch64.zip dist/Artemis_Student_Linux_aarch64.zip
         mv releng/edu.kit.kastel.sdq.eclipse.student.product/target/products/*-macosx.*.x86_64.zip dist/Artemis_Student_MacOS_x86_64.zip
         mv releng/edu.kit.kastel.sdq.eclipse.student.product/target/products/*-macosx.*.aarch64.zip dist/Artemis_Student_MacOS_aarch64.zip
-        
+  
+  upload-mac:
+    name: "Sign and upload of macos distributions"
+    runs-on: macos-latest
+    needs: build
+
+    steps:
+
+    - name: Load Distributions from cache
+      uses: actions/cache@v3
+      with:
+        path: ./dist
+        key: cache-dist-${{github.run_id}}
 
     - name: Sign MacOS Eclipse Distribution (Grading)
       if: startsWith(github.ref, 'refs/tags/v')
@@ -94,25 +118,64 @@ jobs:
         rm dist/Artemis_Student_MacOS_aarch64.zip
         ditto -c -k --sequesterRsrc --keepParent Eclipse.app dist/Artemis_Student_MacOS_aarch64.zip    
 
+    - name: Save Eclipse Distribution (MacOS)
+      uses: actions/upload-artifact@v3
+      with:
+        name: "Eclipse Distribution MacOS"
+        path: "dist/Artemis_*_MacOS*.zip"
+
+  upload-windows:
+    name: "Upload of windows distributions"
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+
+    - name: Load Distributions from cache
+      uses: actions/cache@v3
+      with:
+        path: ./dist
+        key: cache-dist-${{github.run_id}}
+
     - name: Save Eclipse Distribution (Windows)
       uses: actions/upload-artifact@v3
       with:
         name: "Eclipse Distribution Windows"
         path: "dist/Artemis_*_Windows.zip"
-    
+
+  upload-linux:
+    name: "Upload of linux distributions"
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+
+    - name: Load Distributions from cache
+      uses: actions/cache@v3
+      with:
+        path: ./dist
+        key: cache-dist-${{github.run_id}}
+
+
     - name: Save Eclipse Distribution (Linux)
       uses: actions/upload-artifact@v3
       with:
         name: "Eclipse Distribution Linux"
         path: "dist/Artemis_*_Linux*.zip"
 
-    - name: Save Eclipse Distribution (MacOS)
-      uses: actions/upload-artifact@v3
+  release:
+    name: "Create release"
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+
+    - name: Load Distributions from cache
+      uses: actions/cache@v3
       with:
-        name: "Eclipse Distribution MacOS"
-        path: "dist/Artemis_*_MacOS*.zip"
-  
-          
+        path: ./dist
+        key: cache-dist-${{github.run_id}}
+
     - name: Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
<!-- Thanks for contributing to our Artemis Plugin! Before you submit your pull request, please make sure to check the boxes in our checklist. -->

### Checklist
- [x] I tested *all* changes and their related features locally.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link the issue (iff any). -->
Currently building all releases for a PR is painfully slow and takes at least 20 minutes, sometimes up to 30.

This change allows a speedup to typically 10 to 15 minutes ([a test-build can be found here](https://github.com/Shirkanesi/programming-lecture-eclipse-artemis/actions/runs/4034236665)), allowing for less time wasted by waiting and therefore prevents frustration.


### Description

This PR uses two concepts to cut the time:
1) `eatmydata` for the actual maven-build (this obviously needs to happen in linux, not macos!)
2) parallelisation for the artifact upload; the upload-action is way slower than the caching action, therefore up-/downloading the build-artifacts into a cache and then uploading every distribution separately as artifact is much more efficient.

Currently only the pr/main action is changed; if you want I'll also adapt the other slow runs to use this methods. 