### PR TITLE
Add possibility to enable/disable buttons and penalties via Regex

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.common.api/src/edu/kit/kastel/eclipse/common/api/model/IMistakeType.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.api/src/edu/kit/kastel/eclipse/common/api/model/IMistakeType.java
@@ -3,6 +3,8 @@ package edu.kit.kastel.eclipse.common.api.model;
 
 import java.util.List;
 
+import edu.kit.kastel.eclipse.common.api.artemis.mapping.IExercise;
+
 /**
  * Represents one type of mistakes from a rating group.
  *
@@ -58,4 +60,10 @@ public interface IMistakeType {
 	 * @return indicator for custom penalties
 	 */
 	boolean isCustomPenalty();
+
+	void initialize(IExercise exercise);
+
+	boolean isEnabledButton();
+
+	boolean isPenaltyEnabled();
 }

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.api/src/edu/kit/kastel/eclipse/common/api/model/IMistakeType.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.api/src/edu/kit/kastel/eclipse/common/api/model/IMistakeType.java
@@ -63,7 +63,7 @@ public interface IMistakeType {
 
 	void initialize(IExercise exercise);
 
-	boolean isEnabledButton();
+	boolean isEnabledMistakeType();
 
-	boolean isPenaltyEnabled();
+	boolean isEnabledPenalty();
 }

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/AssessmentController.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/AssessmentController.java
@@ -61,7 +61,7 @@ public class AssessmentController extends AbstractController implements IAssessm
 		this.gradingDAO = loadGradingDAO();
 
 		try {
-			ExerciseConfig exerciseConfig = this.gradingDAO.getExerciseConfig();
+			ExerciseConfig exerciseConfig = this.gradingDAO.getExerciseConfig(this.exercise);
 			if (!exerciseConfig.getAllowedExercises().isEmpty() && !exerciseConfig.getAllowedExercises().contains(this.exercise.getExerciseId())) {
 				// using interaction handler of the system wide controller, as the own
 				// interaction handler is not set during the constructor
@@ -132,7 +132,7 @@ public class AssessmentController extends AbstractController implements IAssessm
 	@Override
 	public List<IMistakeType> getMistakes() {
 		try {
-			return gradingDAO.getExerciseConfig().getIMistakeTypes();
+			return gradingDAO.getExerciseConfig(this.exercise).getIMistakeTypes();
 		} catch (ExerciseConfigConverterException | IOException e) {
 			this.error("Exercise Config not parseable: " + e.getMessage(), e);
 			return List.of();
@@ -142,7 +142,7 @@ public class AssessmentController extends AbstractController implements IAssessm
 	@Override
 	public boolean isPositiveFeedbackAllowed() {
 		try {
-			return gradingDAO.getExerciseConfig().isPositiveFeedbackAllowed();
+			return gradingDAO.getExerciseConfig(this.exercise).isPositiveFeedbackAllowed();
 		} catch (ExerciseConfigConverterException | IOException e) {
 			this.error("Exercise Config not parseable: " + e.getMessage(), e);
 			return true;
@@ -162,7 +162,7 @@ public class AssessmentController extends AbstractController implements IAssessm
 	@Override
 	public List<IRatingGroup> getRatingGroups() {
 		try {
-			return gradingDAO.getExerciseConfig().getIRatingGroups();
+			return gradingDAO.getExerciseConfig(this.exercise).getIRatingGroups();
 		} catch (ExerciseConfigConverterException | IOException e) {
 			this.error("Exercise Config not parseable: " + e.getMessage(), e);
 			return List.of();

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/config/ExerciseConfig.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/config/ExerciseConfig.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2022. */
+/* Licensed under EPL-2.0 2022-2023. */
 package edu.kit.kastel.eclipse.common.core.config;
 
 import java.util.ArrayList;
@@ -8,6 +8,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import edu.kit.kastel.eclipse.common.api.artemis.mapping.IExercise;
 import edu.kit.kastel.eclipse.common.api.model.IMistakeType;
 import edu.kit.kastel.eclipse.common.api.model.IRatingGroup;
 import edu.kit.kastel.eclipse.common.core.model.MistakeType;
@@ -52,6 +53,15 @@ public class ExerciseConfig {
 
 	public String getShortName() {
 		return this.shortName;
+	}
+
+	/**
+	 * Modify mistakeTypes of config for the current exercise
+	 *
+	 * @param exercise the exercise
+	 */
+	public void initialize(IExercise exercise) {
+		this.mistakeTypes.forEach(e -> e.initialize(exercise));
 	}
 
 	public boolean isPositiveFeedbackAllowed() {

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/config/GradingDAO.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/config/GradingDAO.java
@@ -1,11 +1,13 @@
-/* Licensed under EPL-2.0 2022. */
+/* Licensed under EPL-2.0 2022-2023. */
 package edu.kit.kastel.eclipse.common.core.config;
 
 import java.io.IOException;
+
+import edu.kit.kastel.eclipse.common.api.artemis.mapping.IExercise;
 
 /**
  * Encapsulates read access to config sources, which might come from a file
  */
 public interface GradingDAO {
-	ExerciseConfig getExerciseConfig() throws IOException, ExerciseConfigConverterException;
+	ExerciseConfig getExerciseConfig(IExercise exercise) throws IOException, ExerciseConfigConverterException;
 }

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/config/JsonFileConfigDAO.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/config/JsonFileConfigDAO.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2022. */
+/* Licensed under EPL-2.0 2022-2023. */
 package edu.kit.kastel.eclipse.common.core.config;
 
 import java.io.File;
@@ -6,6 +6,8 @@ import java.io.IOException;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.kit.kastel.eclipse.common.api.artemis.mapping.IExercise;
 
 /**
  * Implementation of {@link GradingDAO} using a json file.
@@ -23,9 +25,11 @@ public class JsonFileConfigDAO implements GradingDAO {
 	}
 
 	@Override
-	public ExerciseConfig getExerciseConfig() throws IOException, ExerciseConfigConverterException {
-		if (this.exerciseConfig == null)
+	public ExerciseConfig getExerciseConfig(IExercise exercise) throws IOException, ExerciseConfigConverterException {
+		if (this.exerciseConfig == null) {
 			this.parse();
+		}
+		this.exerciseConfig.initialize(exercise);
 		return this.exerciseConfig;
 	}
 

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/model/MistakeType.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/model/MistakeType.java
@@ -7,10 +7,12 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.kit.kastel.eclipse.common.api.artemis.mapping.IExercise;
 import edu.kit.kastel.eclipse.common.api.model.IAnnotation;
 import edu.kit.kastel.eclipse.common.api.model.IMistakeType;
 import edu.kit.kastel.eclipse.common.api.model.IRatingGroup;
 import edu.kit.kastel.eclipse.common.core.model.rule.PenaltyRule;
+import edu.kit.kastel.eclipse.common.core.model.rule.ThresholdPenaltyRule;
 
 public class MistakeType implements IMistakeType {
 	@JsonProperty("shortName")
@@ -35,10 +37,17 @@ public class MistakeType implements IMistakeType {
 	@JsonProperty("penaltyRule")
 	private PenaltyRule penaltyRule;
 
+	@JsonProperty("enabledForExercises")
+	private String enabledForExercises;
+	@JsonProperty("enabledPenaltyForExercises")
+	private String enabledPenaltyForExercises;
+
+	private transient IExercise currentExercise = null;
+
 	@Override
 	public double calculate(List<IAnnotation> annotations) {
 		assert annotations.stream().allMatch(a -> this.equals(a.getMistakeType()));
-		return this.penaltyRule.calculate(annotations);
+		return this.getPenaltyRule().calculate(annotations);
 	}
 
 	/**
@@ -51,16 +60,39 @@ public class MistakeType implements IMistakeType {
 
 	@Override
 	public String getMessage(String languageKey) {
-		if (languageKey == null || additionalMessages == null || !additionalMessages.containsKey(languageKey))
+		if (languageKey == null || additionalMessages == null || !additionalMessages.containsKey(languageKey)) {
 			return this.message;
+		}
 		return additionalMessages.get(languageKey);
 	}
 
 	@Override
 	public String getButtonText(String languageKey) {
-		if (languageKey == null || additionalButtonTexts == null || !additionalButtonTexts.containsKey(languageKey))
+		if (languageKey == null || additionalButtonTexts == null || !additionalButtonTexts.containsKey(languageKey)) {
 			return this.buttonText;
+		}
 		return additionalButtonTexts.get(languageKey);
+	}
+
+	@Override
+	public void initialize(IExercise exercise) {
+		currentExercise = exercise;
+	}
+
+	@Override
+	public boolean isEnabledButton() {
+		if (enabledForExercises == null || currentExercise == null) {
+			return true;
+		}
+		return this.currentExercise.getShortName().matches(this.enabledForExercises);
+	}
+
+	@Override
+	public boolean isPenaltyEnabled() {
+		if (enabledPenaltyForExercises == null || currentExercise == null || penaltyRule.isCustomPenalty()) {
+			return true;
+		}
+		return this.currentExercise.getShortName().matches(this.enabledPenaltyForExercises);
 	}
 
 	@Override
@@ -69,7 +101,11 @@ public class MistakeType implements IMistakeType {
 	}
 
 	public PenaltyRule getPenaltyRule() {
-		return this.penaltyRule;
+		if (isPenaltyEnabled()) {
+			return this.penaltyRule;
+		}
+		// Create penalty with zero points deduction
+		return new ThresholdPenaltyRule(1, 0);
 	}
 
 	@Override
@@ -79,7 +115,7 @@ public class MistakeType implements IMistakeType {
 
 	@Override
 	public String getTooltip(String languageKey, List<IAnnotation> annotations) {
-		String penaltyText = this.penaltyRule.getTooltip(annotations);
+		String penaltyText = getPenaltyRule().getTooltip(annotations);
 		return getMessage(languageKey) + "\n" + penaltyText;
 	}
 

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/model/MistakeType.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/model/MistakeType.java
@@ -51,8 +51,7 @@ public class MistakeType implements IMistakeType {
 	}
 
 	/**
-	 *
-	 * @return to which rating group this applies. Used for deserialization...
+	 * @return to which rating group this applies.
 	 */
 	public String getAppliesTo() {
 		return this.appliesTo;
@@ -80,7 +79,7 @@ public class MistakeType implements IMistakeType {
 	}
 
 	@Override
-	public boolean isEnabledButton() {
+	public boolean isEnabledMistakeType() {
 		if (enabledForExercises == null || currentExercise == null) {
 			return true;
 		}
@@ -88,7 +87,7 @@ public class MistakeType implements IMistakeType {
 	}
 
 	@Override
-	public boolean isPenaltyEnabled() {
+	public boolean isEnabledPenalty() {
 		if (enabledPenaltyForExercises == null || currentExercise == null || penaltyRule.isCustomPenalty()) {
 			return true;
 		}
@@ -101,7 +100,7 @@ public class MistakeType implements IMistakeType {
 	}
 
 	public PenaltyRule getPenaltyRule() {
-		if (isPenaltyEnabled()) {
+		if (isEnabledPenalty()) {
 			return this.penaltyRule;
 		}
 		// Create penalty with zero points deduction

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/model/rule/ThresholdPenaltyRule.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/model/rule/ThresholdPenaltyRule.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2022. */
+/* Licensed under EPL-2.0 2022-2023. */
 package edu.kit.kastel.eclipse.common.core.model.rule;
 
 import java.util.List;
@@ -25,6 +25,11 @@ public class ThresholdPenaltyRule extends PenaltyRule {
 		this.penalty = penaltyRuleNode.get("penalty").asDouble();
 	}
 
+	public ThresholdPenaltyRule(int threshold, double penalty) {
+		this.threshold = threshold;
+		this.penalty = penalty;
+	}
+
 	@Override
 	public double calculate(List<IAnnotation> annotations) {
 		return annotations.size() >= this.threshold ? -this.penalty : 0.D;
@@ -42,6 +47,9 @@ public class ThresholdPenaltyRule extends PenaltyRule {
 
 	@Override
 	public String getTooltip(List<IAnnotation> annotations) {
+		if (penalty == 0) {
+			return annotations.size() + " annotations. No deduction will be made.";
+		}
 		double penaltyValue = this.calculate(annotations);
 		return penaltyValue + " points [" + annotations.size() + " of at least " + this.threshold + " annotations made]";
 	}

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
@@ -30,6 +30,7 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.part.ViewPart;
+import org.eclipse.wb.swt.SWTResourceManager;
 
 import edu.kit.kastel.eclipse.common.api.PreferenceConstants;
 import edu.kit.kastel.eclipse.common.api.controller.IGradingSystemwideController;
@@ -281,6 +282,10 @@ public class ArtemisGradingView extends ViewPart {
 					final Button mistakeButton = new Button(rgDisplay, SWT.PUSH);
 					mistakeButton.setText(mistake.getButtonText(I18N().key()));
 					mistakeButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
+					mistakeButton.setEnabled(mistake.isEnabledButton());
+					if (!mistake.isPenaltyEnabled() && mistake.isEnabledButton()) {
+						mistakeButton.addPaintListener(e -> mistakeButton.setForeground(SWTResourceManager.getColor(SWT.COLOR_CYAN)));
+					}
 
 					this.mistakeButtons.put(mistake.getIdentifier(), mistakeButton);
 					mistakeButton.setToolTipText(this.viewController.getToolTipForMistakeType(I18N().key(), mistake));
@@ -475,12 +480,12 @@ public class ArtemisGradingView extends ViewPart {
 			String openPreference = CommonActivator.getDefault().getPreferenceStore().getString(PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START);
 
 			// Open all types if desired
-			if (openPreference.equals(PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START_ALL)) {
+			if (PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START_ALL.equals(openPreference)) {
 				JDTUtilities.getAllCompilationUnits(project).forEach(c -> AssessmentUtilities.openJavaElement(c, page));
 			}
 
 			// Open/focus the main class
-			if (!openPreference.equals(PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START_NONE)) {
+			if (!PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START_NONE.equals(openPreference)) {
 				var mainType = JDTUtilities.findMainClass(project);
 				if (mainType.isPresent()) {
 					// Open/focus the main class in the editor...

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
@@ -282,8 +282,8 @@ public class ArtemisGradingView extends ViewPart {
 					final Button mistakeButton = new Button(rgDisplay, SWT.PUSH);
 					mistakeButton.setText(mistake.getButtonText(I18N().key()));
 					mistakeButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
-					mistakeButton.setEnabled(mistake.isEnabledButton());
-					if (!mistake.isPenaltyEnabled() && mistake.isEnabledButton()) {
+					mistakeButton.setEnabled(mistake.isEnabledMistakeType());
+					if (!mistake.isEnabledPenalty() && mistake.isEnabledMistakeType()) {
 						mistakeButton.addPaintListener(e -> mistakeButton.setForeground(SWTResourceManager.getColor(SWT.COLOR_CYAN)));
 					}
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -165,6 +165,7 @@ The rating group has an optional property *additionalDisplayNames* that can be u
 A mistake type belongs to a rating group and has a penalty rule that
 defines the penalty calculation logic.
 The mistake type has optional properties *additionalButtonTexts* and *additionalMessages* that can be used to provide additional languages for the view (only in eclipse).
+You can use the optional properties `enabledForExercises` and `enabledPenaltyForExercises` to provide a regex for the exercise short names. If set and not matched the properties will disable the whole button or the penalty for the button.
 
  Config File:
 
@@ -194,7 +195,9 @@ The mistake type has optional properties *additionalButtonTexts* and *additional
             "threshold": 1,
             "penalty": 5
         },
-        "appliesTo": "functionality"
+        "appliesTo": "functionality",
+        "enabledForExercises": "sheet1.*",
+		"enabledPenaltyForExercises": "sheet2.*"
     },
     {
         "shortName": "stackingXY",

--- a/docs/examples/config.json
+++ b/docs/examples/config.json
@@ -65,7 +65,9 @@
 				"threshold": 1,
 				"penalty": 5
 			},
-			"appliesTo": "style"
+			"appliesTo": "style",
+			"enabledForExercises": "sheet1.*",
+			"enabledPenaltyForExercises": "sheet2.*"
 		},
 		{
 			"shortName": "jdTrivial",
@@ -76,7 +78,9 @@
 				"threshold": 1,
 				"penalty": 5
 			},
-			"appliesTo": "style"
+			"appliesTo": "style",
+			"enabledForExercises": "sheet2.*",
+			"enabledPenaltyForExercises": "sheet1.*"
 		},
 		{
 			"shortName": "complexCode",


### PR DESCRIPTION
<!-- Thanks for contributing to our Artemis Plugin! Before you submit your pull request, please make sure to check the boxes in our checklist. -->

### Checklist
- [x] I tested *all* changes and their related features locally or with a test instance of Artemis.
- [x] I documented the Java code using JavaDoc style.
- [x] I documented the changes in the Documentation (/docs).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link the issue (iff any). -->

We want to use a global configuration for grading all tasks of a semester.
These regexes allow the configuration of buttons and their penalties by the short name of the tasks.
