### PR TITLE
Fix insertion of new line when pressing Alt+Enter under Linux/GTK

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/commands/AddAnnotationCommandHandler.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/commands/AddAnnotationCommandHandler.java
@@ -10,6 +10,7 @@ import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
@@ -81,7 +82,12 @@ public class AddAnnotationCommandHandler extends AbstractHandler {
 
 		// Prevent insertion of a new line because the default keybinding is alt+enter
 		if (event.getTrigger() != null) {
-			((Event) event.getTrigger()).doit = false;
+			// Found to work by reverse-engineering Eclipse; cancels the event in
+			// StyledText::traverse
+			((Event) event.getTrigger()).detail = SWT.TRAVERSE_NONE;
+			// doit needs to be true; otherwise Eclipse would do the normal action which is
+			// inserting a new line
+			((Event) event.getTrigger()).doit = true;
 		}
 
 		// Return the focus to the editor

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/commands/AddAnnotationCommandHandler.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/commands/AddAnnotationCommandHandler.java
@@ -83,16 +83,16 @@ public class AddAnnotationCommandHandler extends AbstractHandler {
 		// Prevent insertion of a new line because the default keybinding is alt+enter
 		if (event.getTrigger() != null) {
 			// Windows and GTK behave differently in regard to doit
-			if (System.getProperty("os.name").contains("Windows")) {
-				((Event) event.getTrigger()).doit = false;
-			} else {
-				// We are probably under GTK
+			if (SWT.getPlatform().equals("gtk")) {
 				// Found to work by reverse-engineering Eclipse; cancels the event in
 				// StyledText::traverse
 				((Event) event.getTrigger()).detail = SWT.TRAVERSE_NONE;
 				// doit needs to be true; otherwise Eclipse would do the normal action which is
 				// inserting a new line
 				((Event) event.getTrigger()).doit = true;
+			} else {
+				// Works under Windows, untested on Mac (Cocoa)
+				((Event) event.getTrigger()).doit = false;
 			}
 		}
 

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/commands/AddAnnotationCommandHandler.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/commands/AddAnnotationCommandHandler.java
@@ -82,12 +82,18 @@ public class AddAnnotationCommandHandler extends AbstractHandler {
 
 		// Prevent insertion of a new line because the default keybinding is alt+enter
 		if (event.getTrigger() != null) {
-			// Found to work by reverse-engineering Eclipse; cancels the event in
-			// StyledText::traverse
-			((Event) event.getTrigger()).detail = SWT.TRAVERSE_NONE;
-			// doit needs to be true; otherwise Eclipse would do the normal action which is
-			// inserting a new line
-			((Event) event.getTrigger()).doit = true;
+			// Windows and GTK behave differently in regard to doit
+			if (System.getProperty("os.name").contains("Windows")) {
+				((Event) event.getTrigger()).doit = false;
+			} else {
+				// We are probably under GTK
+				// Found to work by reverse-engineering Eclipse; cancels the event in
+				// StyledText::traverse
+				((Event) event.getTrigger()).detail = SWT.TRAVERSE_NONE;
+				// doit needs to be true; otherwise Eclipse would do the normal action which is
+				// inserting a new line
+				((Event) event.getTrigger()).doit = true;
+			}
 		}
 
 		// Return the focus to the editor


### PR DESCRIPTION
<!-- Thanks for contributing to our Artemis Plugin! Before you submit your pull request, please make sure to check the boxes in our checklist. -->

### Checklist
- [x] I tested *all* changes and their related features locally or with a test instance of Artemis.

### Motivation and Context
Pressing Alt+Enter inserts a new line after closing the annotation selection window.

### Description
I've basically reverse engineered the event handling code of Eclipse under Windows and GTK and found configurations that work well. However, everything may fall apart on MacOS, since I couldn't test it

### Steps for Testing
Press Alt+Enter in the editor after starting an assessment.
