### PR TITLE
Replace button text color for newly enabled buttons

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
@@ -298,7 +298,7 @@ public class ArtemisGradingView extends ViewPart {
 					mistakeButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
 					mistakeButton.setEnabled(mistake.isEnabledMistakeType());
 					if (!mistake.isEnabledPenalty() && mistake.isEnabledMistakeType()) {
-						mistakeButton.addPaintListener(e -> mistakeButton.setForeground(SWTResourceManager.getColor(SWT.COLOR_CYAN)));
+						mistakeButton.addPaintListener(e -> mistakeButton.setForeground(SWTResourceManager.getColor(133, 153, 0))); // solarized green
 					}
 
 					this.mistakeButtons.put(mistake.getIdentifier(), mistakeButton);


### PR DESCRIPTION
### Checklist
- [ ] I tested *all* changes and their related features locally or with a test instance of Artemis.
- [ ] I documented the Java code using JavaDoc style.
- [ ] I documented the changes in the Documentation (/docs).

### Motivation and Context
Buttons that are newly enabled for a task but do not deduct points yet are highlighted via color.
The button text color was Cyan, thus ugly in both dark and light themes.

### Description
Now the color is [solarized green](https://en.wikipedia.org/wiki/Solarized#Colors).
In the future, maybe the user can actually change the color via the settings. This PR is just a hotfix.

### Steps for Testing
Load config where at least one button is enabled for exercise but not yet enabled for penalty.
