### PR TITLE
Fixes for the delete annotations dialog

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/commands/DeleteAnnotationDialog.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/commands/DeleteAnnotationDialog.java
@@ -62,7 +62,7 @@ public class DeleteAnnotationDialog extends Dialog {
 		container.setLayout(layout);
 
 		Label delInfo = new Label(container, SWT.NONE);
-		delInfo.setText("Press Del to delete");
+		delInfo.setText("Press Backspace or Del to delete");
 		delInfo.setForeground(new Color(100, 100, 100));
 		this.createAnnotationList(container);
 		this.updateAnnotations();


### PR DESCRIPTION
<!-- Thanks for contributing to our Artemis Plugin! Before you submit your pull request, please make sure to check the boxes in our checklist. -->

### Checklist
- [x] I tested *all* changes and their related features locally or with a test instance of Artemis.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
* Allows backspace for deleting annotations
* No longer closes the dialog after deleting an annotation
* Only shows annotations in the current file and not all annotations that span the current line, but are in other files

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
