### PR TITLE
✨ add custom text color in buttons

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.common.api/src/edu/kit/kastel/eclipse/common/api/PreferenceConstants.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.api/src/edu/kit/kastel/eclipse/common/api/PreferenceConstants.java
@@ -22,7 +22,10 @@ public final class PreferenceConstants {
 
 	public static final String SEARCH_IN_MISTAKE_MESSAGES = "searchInMistakeMessages";
 
-	public static final String COLOR_IN_BUTTONS_WITHOUT_PENALTY ="colorInButtonsWithoutPenalty";
+	public static final String GRADING_VIEW_BUTTONS_COLOR_DISABLED = "buttonsColorDisabled";
+	public static final String GRADING_VIEW_BUTTONS_COLOR_ENABLED = "buttonsColorEnabled";
+	public static final String GRADING_VIEW_BUTTONS_COLOR_PENALTY = "buttonsColorPenalty";
+	public static final String GRADING_VIEW_BUTTONS_COLOR_LIMIT_REACHED = "buttonsColorLimitReached";
 
 	public static final String OPEN_FILES_ON_ASSESSMENT_START = "openFilesOnAssessmentStart";
 	public static final String OPEN_FILES_ON_ASSESSMENT_START_ALL = "all";

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.api/src/edu/kit/kastel/eclipse/common/api/PreferenceConstants.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.api/src/edu/kit/kastel/eclipse/common/api/PreferenceConstants.java
@@ -22,6 +22,8 @@ public final class PreferenceConstants {
 
 	public static final String SEARCH_IN_MISTAKE_MESSAGES = "searchInMistakeMessages";
 
+	public static final String COLOR_IN_BUTTONS_WITHOUT_PENALTY ="colorInButtonsWithoutPenalty";
+
 	public static final String OPEN_FILES_ON_ASSESSMENT_START = "openFilesOnAssessmentStart";
 	public static final String OPEN_FILES_ON_ASSESSMENT_START_ALL = "all";
 	public static final String OPEN_FILES_ON_ASSESSMENT_START_MAIN = "main";

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/languages/GermanLanguage.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/languages/GermanLanguage.java
@@ -201,8 +201,23 @@ class GermanLanguage implements I18N {
 	}
 
 	@Override
-	public String settingsColorInButtonsWithoutPenalty() {
-			return "Farbe in Buttons ohne Abzug";
+	public String settingsButtonsColorDisabled() {
+		return "Textfarbe in deaktivierten Buttons";
+	}
+
+	@Override
+	public String settingsButtonsColorEnabled() {
+		return "Textfarbe in aktivierten Buttons";
+	}
+
+	@Override
+	public String settingsButtonsColorPenalty() {
+		return "Textfarbe in Buttons mit Abzug";
+	}
+
+	@Override
+	public String settingsButtonsColorLimitReached() {
+		return "Textfarbe in Buttons mit erreichtem Abzugslimit";
 	}
 
 	@Override

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/languages/GermanLanguage.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/languages/GermanLanguage.java
@@ -201,6 +201,11 @@ class GermanLanguage implements I18N {
 	}
 
 	@Override
+	public String settingsColorInButtonsWithoutPenalty() {
+			return "Farbe in Buttons ohne Abzug";
+	}
+
+	@Override
 	public String settingsOpenFilesOnAssessmentStart() {
 		return "Dateien automatisch öffnen";
 	}

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/languages/I18N.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/languages/I18N.java
@@ -218,6 +218,7 @@ public interface I18N {
 	default String settingsButtonsColorLimitReached() {
 		return "Text color in buttons with reached penalties limit";
 	}
+
 	default String settingsOpenFilesOnAssessmentStart() {
 		return "Open files automatically";
 	}

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/languages/I18N.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/languages/I18N.java
@@ -203,6 +203,10 @@ public interface I18N {
 		return "Search in button descriptions";
 	}
 
+	default String settingsColorInButtonsWithoutPenalty() {
+		return "Color in buttons without penalty";
+	}
+
 	default String settingsOpenFilesOnAssessmentStart() {
 		return "Open files automatically";
 	}

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/languages/I18N.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/languages/I18N.java
@@ -203,10 +203,21 @@ public interface I18N {
 		return "Search in button descriptions";
 	}
 
-	default String settingsColorInButtonsWithoutPenalty() {
-		return "Color in buttons without penalty";
+	default String settingsButtonsColorDisabled() {
+		return "Text color in deactivated buttons";
 	}
 
+	default String settingsButtonsColorEnabled() {
+		return "Text color in activated buttons";
+	}
+
+	default String settingsButtonsColorPenalty() {
+		return "Text color in buttons with penalties";
+	}
+
+	default String settingsButtonsColorLimitReached() {
+		return "Text color in buttons with reached penalties limit";
+	}
 	default String settingsOpenFilesOnAssessmentStart() {
 		return "Open files automatically";
 	}

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/preferences/AdvancedPreferences.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/preferences/AdvancedPreferences.java
@@ -49,7 +49,10 @@ public class AdvancedPreferences extends FieldEditorPreferencePage implements IW
 
 		var searchInMistakeMessages = new BooleanFieldEditor(PreferenceConstants.SEARCH_IN_MISTAKE_MESSAGES, I18N().settingsSearchInMistakeMessages(), parent);
 
-		var colorInButtonsWithoutPenalty = new ColorFieldEditor(PreferenceConstants.COLOR_IN_BUTTONS_WITHOUT_PENALTY, I18N().settingsColorInButtonsWithoutPenalty(), parent);
+		var buttonsColorDisabled = new ColorFieldEditor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_DISABLED, I18N().settingsButtonsColorDisabled(), parent);
+		var buttonsColorEnabled = new ColorFieldEditor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_ENABLED, I18N().settingsButtonsColorEnabled(), parent);
+		var buttonsColorPenalty = new ColorFieldEditor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_PENALTY, I18N().settingsButtonsColorPenalty(), parent);
+		var buttonsColorLimitReached = new ColorFieldEditor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_LIMIT_REACHED, I18N().settingsButtonsColorLimitReached(), parent);
 
 		var columnsForGradingButtons = new IntegerFieldEditor(PreferenceConstants.GRADING_VIEW_BUTTONS_IN_COLUMN,
 				I18N().settingsAmountOfGradingButtonsInOneRow(), parent);
@@ -75,7 +78,10 @@ public class AdvancedPreferences extends FieldEditorPreferencePage implements IW
 		this.addField(userPrefersTextWrappingInPenaltyText);
 		this.addField(overrideDefaultPreferences);
 		this.addField(searchInMistakeMessages);
-		this.addField(colorInButtonsWithoutPenalty);
+		this.addField(buttonsColorDisabled);
+		this.addField(buttonsColorEnabled);
+		this.addField(buttonsColorPenalty);
+		this.addField(buttonsColorLimitReached);
 		this.addField(openFiles);
 
 		this.addField(autograderDownloadJar);

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/preferences/AdvancedPreferences.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/preferences/AdvancedPreferences.java
@@ -4,6 +4,7 @@ package edu.kit.kastel.eclipse.common.view.preferences;
 import static edu.kit.kastel.eclipse.common.view.languages.LanguageSettings.I18N;
 
 import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.ColorFieldEditor;
 import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.IntegerFieldEditor;
@@ -48,6 +49,8 @@ public class AdvancedPreferences extends FieldEditorPreferencePage implements IW
 
 		var searchInMistakeMessages = new BooleanFieldEditor(PreferenceConstants.SEARCH_IN_MISTAKE_MESSAGES, I18N().settingsSearchInMistakeMessages(), parent);
 
+		var colorInButtonsWithoutPenalty = new ColorFieldEditor(PreferenceConstants.COLOR_IN_BUTTONS_WITHOUT_PENALTY, I18N().settingsColorInButtonsWithoutPenalty(), parent);
+
 		var columnsForGradingButtons = new IntegerFieldEditor(PreferenceConstants.GRADING_VIEW_BUTTONS_IN_COLUMN,
 				I18N().settingsAmountOfGradingButtonsInOneRow(), parent);
 		columnsForGradingButtons.setEmptyStringAllowed(false);
@@ -72,6 +75,7 @@ public class AdvancedPreferences extends FieldEditorPreferencePage implements IW
 		this.addField(userPrefersTextWrappingInPenaltyText);
 		this.addField(overrideDefaultPreferences);
 		this.addField(searchInMistakeMessages);
+		this.addField(colorInButtonsWithoutPenalty);
 		this.addField(openFiles);
 
 		this.addField(autograderDownloadJar);

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/preferences/AdvancedPreferences.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/preferences/AdvancedPreferences.java
@@ -52,7 +52,8 @@ public class AdvancedPreferences extends FieldEditorPreferencePage implements IW
 		var buttonsColorDisabled = new ColorFieldEditor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_DISABLED, I18N().settingsButtonsColorDisabled(), parent);
 		var buttonsColorEnabled = new ColorFieldEditor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_ENABLED, I18N().settingsButtonsColorEnabled(), parent);
 		var buttonsColorPenalty = new ColorFieldEditor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_PENALTY, I18N().settingsButtonsColorPenalty(), parent);
-		var buttonsColorLimitReached = new ColorFieldEditor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_LIMIT_REACHED, I18N().settingsButtonsColorLimitReached(), parent);
+		var buttonsColorLimitReached = new ColorFieldEditor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_LIMIT_REACHED,
+				I18N().settingsButtonsColorLimitReached(), parent);
 
 		var columnsForGradingButtons = new IntegerFieldEditor(PreferenceConstants.GRADING_VIEW_BUTTONS_IN_COLUMN,
 				I18N().settingsAmountOfGradingButtonsInOneRow(), parent);

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/preferences/PreferenceInitializer.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/preferences/PreferenceInitializer.java
@@ -28,7 +28,12 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		store.setDefault(PreferenceConstants.GENERAL_OVERRIDE_DEFAULT_PREFERENCES, true);
 		store.setDefault(PreferenceConstants.GENERAL_PREFERRED_LANGUAGE, LanguageSettings.getDefaultLanguage().languageDisplayName());
 		store.setDefault(PreferenceConstants.SEARCH_IN_MISTAKE_MESSAGES, true);
-		store.setDefault(PreferenceConstants.COLOR_IN_BUTTONS_WITHOUT_PENALTY, "133, 153, 0"); // solarized green
+
+		store.setDefault(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_DISABLED, "131,148,150"); // solarized brblue
+		store.setDefault(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_ENABLED, "133,153,0"); // solarized green
+		store.setDefault(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_PENALTY, "181,137,0"); // solarized yellow
+		store.setDefault(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_LIMIT_REACHED, "211,54,130"); // solarized magenta
+
 		store.setDefault(PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START, PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START_MAIN);
 
 		store.setDefault(PreferenceConstants.AUTOGRADER_DOWNLOAD_JAR, true);

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/preferences/PreferenceInitializer.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.view/src/edu/kit/kastel/eclipse/common/view/preferences/PreferenceInitializer.java
@@ -28,6 +28,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		store.setDefault(PreferenceConstants.GENERAL_OVERRIDE_DEFAULT_PREFERENCES, true);
 		store.setDefault(PreferenceConstants.GENERAL_PREFERRED_LANGUAGE, LanguageSettings.getDefaultLanguage().languageDisplayName());
 		store.setDefault(PreferenceConstants.SEARCH_IN_MISTAKE_MESSAGES, true);
+		store.setDefault(PreferenceConstants.COLOR_IN_BUTTONS_WITHOUT_PENALTY, "133, 153, 0"); // solarized green
 		store.setDefault(PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START, PreferenceConstants.OPEN_FILES_ON_ASSESSMENT_START_MAIN);
 
 		store.setDefault(PreferenceConstants.AUTOGRADER_DOWNLOAD_JAR, true);

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
@@ -301,9 +301,13 @@ public class ArtemisGradingView extends ViewPart {
 					final Button mistakeButton = new Button(rgDisplay, SWT.PUSH);
 					mistakeButton.setText(mistake.getButtonText(I18N().key()));
 					mistakeButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
-					mistakeButton.setEnabled(mistake.isEnabledMistakeType());
-					if (!mistake.isEnabledPenalty() && mistake.isEnabledMistakeType()) {
-						mistakeButton.addPaintListener(e -> mistakeButton.setForeground(SWTResourceManager.getColor(loadColorInButtonsWithoutPenalty())));
+					if (mistake.isEnabledMistakeType() && mistake.isEnabledPenalty()) {
+						mistakeButton.addPaintListener(e -> mistakeButton.setForeground(SWTResourceManager.getColor(loadButtonsColor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_PENALTY))));
+					} else if (mistake.isEnabledMistakeType()) {
+						mistakeButton.addPaintListener(e -> mistakeButton.setForeground(SWTResourceManager.getColor(loadButtonsColor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_ENABLED))));
+					} else {
+						mistakeButton.addPaintListener(e -> mistakeButton.setForeground(SWTResourceManager.getColor(loadButtonsColor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_DISABLED))));
+						mistakeButton.setEnabled(false);
 					}
 
 					this.mistakeButtons.put(mistake.getIdentifier(), mistakeButton);
@@ -329,8 +333,8 @@ public class ArtemisGradingView extends ViewPart {
 		UIUtilities.initializeTabAfterFilling(container, this.gradingButtonComposite);
 	}
 
-	private RGB loadColorInButtonsWithoutPenalty() {
-		int[] rgb = Arrays.stream(CommonActivator.getDefault().getPreferenceStore().getString(PreferenceConstants.COLOR_IN_BUTTONS_WITHOUT_PENALTY).split(",")).mapToInt(Integer::parseInt).toArray();
+	private RGB loadButtonsColor(String preferenceKey) {
+		int[] rgb = Arrays.stream(CommonActivator.getDefault().getPreferenceStore().getString(preferenceKey).split(",")).mapToInt(Integer::parseInt).toArray();
 		return new RGB(rgb[0], rgb[1], rgb[2]);
 	}
 

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
@@ -16,6 +16,7 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -302,7 +303,7 @@ public class ArtemisGradingView extends ViewPart {
 					mistakeButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
 					mistakeButton.setEnabled(mistake.isEnabledMistakeType());
 					if (!mistake.isEnabledPenalty() && mistake.isEnabledMistakeType()) {
-						mistakeButton.addPaintListener(e -> mistakeButton.setForeground(SWTResourceManager.getColor(133, 153, 0))); // solarized green
+						mistakeButton.addPaintListener(e -> mistakeButton.setForeground(SWTResourceManager.getColor(loadColorInButtonsWithoutPenalty())));
 					}
 
 					this.mistakeButtons.put(mistake.getIdentifier(), mistakeButton);
@@ -326,6 +327,11 @@ public class ArtemisGradingView extends ViewPart {
 		});
 
 		UIUtilities.initializeTabAfterFilling(container, this.gradingButtonComposite);
+	}
+
+	private RGB loadColorInButtonsWithoutPenalty() {
+		int[] rgb = Arrays.stream(CommonActivator.getDefault().getPreferenceStore().getString(PreferenceConstants.COLOR_IN_BUTTONS_WITHOUT_PENALTY).split(",")).mapToInt(Integer::parseInt).toArray();
+		return new RGB(rgb[0], rgb[1], rgb[2]);
 	}
 
 	/**

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/assessment/ArtemisGradingView.java
@@ -302,11 +302,14 @@ public class ArtemisGradingView extends ViewPart {
 					mistakeButton.setText(mistake.getButtonText(I18N().key()));
 					mistakeButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
 					if (mistake.isEnabledMistakeType() && mistake.isEnabledPenalty()) {
-						mistakeButton.addPaintListener(e -> mistakeButton.setForeground(SWTResourceManager.getColor(loadButtonsColor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_PENALTY))));
+						mistakeButton.addPaintListener(e -> mistakeButton
+								.setForeground(SWTResourceManager.getColor(loadButtonsColor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_PENALTY))));
 					} else if (mistake.isEnabledMistakeType()) {
-						mistakeButton.addPaintListener(e -> mistakeButton.setForeground(SWTResourceManager.getColor(loadButtonsColor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_ENABLED))));
+						mistakeButton.addPaintListener(e -> mistakeButton
+								.setForeground(SWTResourceManager.getColor(loadButtonsColor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_ENABLED))));
 					} else {
-						mistakeButton.addPaintListener(e -> mistakeButton.setForeground(SWTResourceManager.getColor(loadButtonsColor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_DISABLED))));
+						mistakeButton.addPaintListener(e -> mistakeButton
+								.setForeground(SWTResourceManager.getColor(loadButtonsColor(PreferenceConstants.GRADING_VIEW_BUTTONS_COLOR_DISABLED))));
 						mistakeButton.setEnabled(false);
 					}
 


### PR DESCRIPTION
### Checklist

- [x] I tested *all* changes and their related features locally or with a test instance of Artemis.
- [ ] I documented the Java code using JavaDoc style.
- [ ] I documented the changes in the Documentation (/docs).

### Motivation and Context

In some themes the green text color on the buttons does not look very nice.

### Description

Follow-up to pull request #315 with extended settings to change the text color for buttons. The default value for a button without penalty remains solarized green. Overall the colors:

* disabled button, no action: gray
* enabled button, no penalty: green
* enabled button, with penalty, no limit reached: yellow
* enabled button, with penalty, limit reached: magenta

Reaching a limit for the buttons still needs to be implemented. The corresponding calculation for this already exists in the MistakeTypes. This would also close issue #199.

Furthermore, the display should not be marked purely by colors, in the sense of accessibility. Formatting (e.g. strikethrough, bold) has been suggested, but this cannot be implemented with the current text buttons alone.

### Steps for Testing

Open Window > Preferences > Artemis > Advanced and set color. Load assessment and look at your beautiful selection.
