### PR TITLE
✨ show lock state in backlog

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/artemis/naming/DefaultProjectFileNamingStrategy.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/artemis/naming/DefaultProjectFileNamingStrategy.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2022-2023. */
+/* Licensed under EPL-2.0 2022-2024. */
 package edu.kit.kastel.eclipse.common.core.artemis.naming;
 
 import java.io.File;

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/artemis/naming/DefaultProjectFileNamingStrategy.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/artemis/naming/DefaultProjectFileNamingStrategy.java
@@ -11,7 +11,7 @@ import edu.kit.kastel.sdq.artemis4j.api.artemis.assessment.Submission;
  * A naming strategy that creates projects like this:
  *
  * <pre>
- * exercise-${EXERCISE_ID}-${EXERCISE_SHORTNAME}-${STUDENT_ID}-round-${round}-submission-${SUBMISSION_ID}}
+ * exercise-${EXERCISE_ID}-${EXERCISE_SHORTNAME}-${STUDENT_ID}-round-${round}-submission-${SUBMISSION_ID}${-locked}
  * </pre>
  *
  */

--- a/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/artemis/naming/DefaultProjectFileNamingStrategy.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.common.core/src/edu/kit/kastel/eclipse/common/core/artemis/naming/DefaultProjectFileNamingStrategy.java
@@ -32,9 +32,12 @@ public class DefaultProjectFileNamingStrategy implements IProjectFileNamingStrat
 		String projectName = "";
 		projectName += "exercise-" + exercise.getExerciseId() + "-" + exercise.getShortName();
 		if (submission != null) {
+			var result = submission.getResult(submission.getCorrectionRound());
+
 			projectName += "-" + submission.getParticipantIdentifier();
 			projectName += "-round-" + (submission.getCorrectionRound() + 1);
 			projectName += "-submission-" + submission.getSubmissionId();
+			projectName += (result != null && result.completionDate != null) ? "" : "-locked";
 		}
 		return new File(workspaceDirectory, projectName);
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to our Artemis Plugin! Before you submit your pull request, please make sure to check the boxes in our checklist. -->

### Checklist
- [x] I tested *all* changes and their related features locally or with a test instance of Artemis.
- [x] I documented the Java code using JavaDoc style.
- [ ] I documented the changes in the Documentation (/docs).

### Motivation and Context

Artemis shows unsubmitted assessments; the grading tool does not (or more specifically just that there is *something* locked).

### Description
 
Changes the description in the backlog to append `-locked` on unsubmitted assessments.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

The tricky part: there is a related pr https://github.com/kit-sdq/artemis4j/pull/37 to get the result per correction round, but i didn't have an exercise with multiple rounds for test purposes.